### PR TITLE
Add support for Delete of entries.

### DIFF
--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -26,13 +26,13 @@ import (
 	"github.com/openconfig/gribigo/negtest"
 	"github.com/openconfig/gribigo/server"
 	"github.com/openconfig/gribigo/testcommon"
-	wpb "github.com/openconfig/ygot/proto/ywrapper"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	aftpb "github.com/openconfig/gribi/v1/proto/gribi_aft"
 	spb "github.com/openconfig/gribi/v1/proto/service"
+	wpb "github.com/openconfig/ygot/proto/ywrapper"
 )
 
 func TestGRIBIClient(t *testing.T) {
@@ -97,7 +97,6 @@ func TestGRIBIClient(t *testing.T) {
 			c.Start(context.Background(), t)
 			nh := NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(1)
 			c.Modify().AddEntry(t, nh)
-			c.Modify().ReplaceEntry(t, nh)
 			c.Modify().DeleteEntry(t, nh)
 			c.StartSending(context.Background(), t)
 			// NB: we don't actually check any of the return values here, we

--- a/rib/rib.go
+++ b/rib/rib.go
@@ -374,6 +374,7 @@ func (r *RIB) DeleteEntry(ni string, op *spb.AFTOperation) ([]*OpResult, []*OpRe
 	default:
 		return nil, nil, status.Newf(codes.Unimplemented, "unsupported AFT operation type %T", t).Err()
 	}
+
 	switch {
 	case err != nil:
 		fails = append(fails, &OpResult{

--- a/rib/rib.go
+++ b/rib/rib.go
@@ -840,25 +840,6 @@ func (r *RIBHolder) DeleteNextHop(e *aftpb.Afts_NextHopKey) (bool, error) {
 	return true, nil
 }
 
-// ipv4EntryProto returns a protobuf message for the specified IPv4 prefix. It returns
-// the found prefix as a Ipv4EntryKey protobuf, along with a bool indicating whether the
-// prefix was found in the RIB.
-func (r *RIBHolder) ipv4EntryProto(pfx string) (*aftpb.Afts_Ipv4EntryKey, bool, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	ribE := r.r.Afts.Ipv4Entry[pfx]
-	if ribE == nil {
-		return nil, false, nil
-	}
-
-	existingEntryProto, err := concreteIPv4Proto(ribE)
-	if err != nil {
-		return nil, true, status.Newf(codes.Internal, "invalid existing entry in RIB %v", ribE).Err()
-	}
-
-	return existingEntryProto, true, nil
-}
-
 // doDeleteIPv4 deletes pfx from the IPv4Entry RIB holding the shortest possible lock.
 func (r *RIBHolder) doDeleteIPv4(pfx string) {
 	r.mu.Lock()

--- a/server/server.go
+++ b/server/server.go
@@ -725,8 +725,6 @@ func modifyEntry(r *rib.RIB, ni string, op *spb.AFTOperation, fibACK bool, elect
 		oks, faileds, err = r.AddEntry(ni, op)
 	case spb.AFTOperation_DELETE:
 		oks, faileds, err = r.DeleteEntry(ni, op)
-	//case spb.AFTOperation_REPLACE:
-	//	oks, faileds, err = r.ReplaceEntry(ni, op)
 	default:
 		return nil, status.Newf(codes.InvalidArgument, "invalid operation type supplied, %s", op.Op).Err()
 	}


### PR DESCRIPTION
```
 * (M) fluent/fluent.go
 * (M) fluent/fluent_test.go
   - Add Status() to retrieve client status in tests - this allows for send and
     receive errors to be checked.
   - Add DeleteEntry() function to submit a set of entries to be deleted by the
     server, and corresponding ReplaceEntry() function.
 * (M) rib/rib.go
 * (M) rib/rib_test.go
   - Add top-level DeleteEntry function that can take an operation from the caller.
   - Fix DeleteIPv4 to not check content as per design discussion.
   - Add DeleteNextHopGroup and DeleteNextHop.
   - Test coverage for individual DeleteXXX and the overall DeleteEntry.
   - Improve test coverage by injecting check functions that inject errors and
     programming failures.
 * (M) server/server.go
 * (M) server/server_test.go
   - Add support for delete and replace in doModify by generalising addEntry.
     This ensures that we do not have multiple places in the implementation
     that need to be aware of each operation.
```
