### PR TITLE
Add helper function to find the next-hops for a particular prefix.

### DIFF
--- a/a
+++ b/a
@@ -1,6 +1,0 @@
-Merge branch 'delete-replace-1' into delete-replace-2
-# Please enter a commit message to explain why this merge is necessary,
-# especially if it merges an updated upstream into a topic branch.
-#
-# Lines starting with '#' will be ignored, and an empty message aborts
-# the commit.

--- a/afthelper/afthelper.go
+++ b/afthelper/afthelper.go
@@ -1,0 +1,84 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package afthelper provides helper functions for handling the OpenConfig
+// AFT schema.
+package afthelper
+
+import (
+	"fmt"
+
+	"github.com/openconfig/gribigo/aft"
+)
+
+// NextHopSummary provides a summary of an next-hop for a particular entry.
+type NextHopSummary struct {
+	// Weight is the share of traffic that the next-hop gets.
+	Weight uint64
+	// Address is the IP address of the next-hop.
+	Address string
+	// NetworkInstance is the network instance within which the address was resolved.
+	NetworkInstance string
+}
+
+// NextHopAddrsForPrefix unrolls the prefix specified within the network-instance netInst from the
+// specified ribs. It returns a map of next-hop IP address to a summary of the resolved next-hop.
+//
+// TODO(robjs): support recursion.
+func NextHopAddrsForPrefix(rib map[string]*aft.RIB, netinst, prefix string) (map[string]*NextHopSummary, error) {
+	niAFT, ok := rib[netinst]
+	if !ok {
+		return nil, fmt.Errorf("network instance %s does not exist", netinst)
+	}
+
+	v4 := niAFT.GetAfts().GetIpv4Entry(prefix)
+	if v4 == nil {
+		return nil, fmt.Errorf("cannot find IPv4 prefix in AFT")
+	}
+
+	nhNI := netinst
+	if otherNI := v4.GetNextHopGroupNetworkInstance(); otherNI != "" {
+		nhNI = otherNI
+	}
+
+	if _, ok := rib[nhNI]; !ok {
+		return nil, fmt.Errorf("got invalid network instance, %s", nhNI)
+	}
+
+	nhg := rib[nhNI].GetAfts().GetNextHopGroup(v4.GetNextHopGroup())
+	if nhg == nil {
+		return nil, fmt.Errorf("got unknown NHG %d in NI %s", v4.GetNextHopGroup(), nhNI)
+	}
+
+	// sum is a map of index -> weight.
+	weights := map[uint64]uint64{}
+	for _, nh := range nhg.NextHop {
+		weights[nh.GetIndex()] = nh.GetWeight()
+	}
+
+	ret := map[string]*NextHopSummary{}
+	for nhID := range weights {
+		nh := rib[nhNI].GetAfts().GetNextHop(nhID).GetIpAddress()
+		if nh == "" {
+			return nil, fmt.Errorf("invalid next-hop %d", nhID)
+		}
+		ret[nh] = &NextHopSummary{
+			Address:         nh,
+			Weight:          weights[nhID],
+			NetworkInstance: nhNI,
+		}
+	}
+
+	return ret, nil
+}

--- a/afthelper/afthelper_test.go
+++ b/afthelper/afthelper_test.go
@@ -1,0 +1,123 @@
+package afthelper
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/gribigo/aft"
+	"github.com/openconfig/ygot/ygot"
+)
+
+const (
+	defName = "DEFAULT"
+)
+
+func TestNextHopAddrsForPrefix(t *testing.T) {
+
+	tests := []struct {
+		desc      string
+		inRIB     map[string]*aft.RIB
+		inNetInst string
+		inPrefix  string
+		want      map[string]*NextHopSummary
+		wantErr   bool
+	}{{
+		desc: "simple ipv4 to one NH",
+		inRIB: map[string]*aft.RIB{
+			defName: func() *aft.RIB {
+				r := &aft.RIB{}
+				r.GetOrCreateAfts().GetOrCreateIpv4Entry("8.8.8.8/32").NextHopGroup = ygot.Uint64(1)
+				r.GetOrCreateAfts().GetOrCreateNextHopGroup(1).GetOrCreateNextHop(1).Weight = ygot.Uint64(1)
+				r.GetOrCreateAfts().GetOrCreateNextHop(1).IpAddress = ygot.String("1.1.1.1")
+				return r
+			}(),
+		},
+		inNetInst: defName,
+		inPrefix:  "8.8.8.8/32",
+		want: map[string]*NextHopSummary{
+			"1.1.1.1": {
+				Weight:          1,
+				Address:         "1.1.1.1",
+				NetworkInstance: defName,
+			},
+		},
+	}, {
+		desc: "ipv4 with two NH",
+		inRIB: map[string]*aft.RIB{
+			defName: func() *aft.RIB {
+				r := &aft.RIB{}
+				r.GetOrCreateAfts().GetOrCreateIpv4Entry("8.8.8.8/32").NextHopGroup = ygot.Uint64(1)
+				r.GetOrCreateAfts().GetOrCreateNextHopGroup(1).GetOrCreateNextHop(1).Weight = ygot.Uint64(1)
+				r.GetOrCreateAfts().GetOrCreateNextHopGroup(1).GetOrCreateNextHop(2).Weight = ygot.Uint64(1)
+				r.GetOrCreateAfts().GetOrCreateNextHop(1).IpAddress = ygot.String("1.1.1.1")
+				r.GetOrCreateAfts().GetOrCreateNextHop(2).IpAddress = ygot.String("2.2.2.2")
+				return r
+			}(),
+		},
+		inNetInst: defName,
+		inPrefix:  "8.8.8.8/32",
+		want: map[string]*NextHopSummary{
+			"1.1.1.1": {
+				Address:         "1.1.1.1",
+				Weight:          1,
+				NetworkInstance: defName,
+			},
+			"2.2.2.2": {
+				Address:         "2.2.2.2",
+				Weight:          1,
+				NetworkInstance: defName,
+			},
+		},
+	}, {
+		desc:      "can't find network instance",
+		inRIB:     map[string]*aft.RIB{},
+		inNetInst: "fish",
+		wantErr:   true,
+	}, {
+		desc: "can't find ipv4 prefix",
+		inRIB: map[string]*aft.RIB{
+			defName: {},
+		},
+		inPrefix: "42.42.42.42/32",
+		wantErr:  true,
+	}, {
+		desc: "ipv4 with next-hop-group in another network instance",
+		inRIB: map[string]*aft.RIB{
+			defName: func() *aft.RIB {
+				r := &aft.RIB{}
+				v4 := r.GetOrCreateAfts().GetOrCreateIpv4Entry("1.2.3.4/32")
+				v4.NextHopGroup = ygot.Uint64(1)
+				v4.NextHopGroupNetworkInstance = ygot.String("VRF-1")
+				return r
+			}(),
+			"VRF-1": func() *aft.RIB {
+				r := &aft.RIB{}
+				r.GetOrCreateAfts().GetOrCreateNextHopGroup(1).GetOrCreateNextHop(2).Weight = ygot.Uint64(2)
+				r.GetOrCreateAfts().GetOrCreateNextHop(2).IpAddress = ygot.String("2.2.2.2")
+				return r
+			}(),
+		},
+		inPrefix:  "1.2.3.4/32",
+		inNetInst: defName,
+		want: map[string]*NextHopSummary{
+			"2.2.2.2": {
+				Weight:          2,
+				Address:         "2.2.2.2",
+				NetworkInstance: "VRF-1",
+			},
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := NextHopAddrsForPrefix(tt.inRIB, tt.inNetInst, tt.inPrefix)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("did not get expected error, got: %v, wantErr? %v", err, tt.wantErr)
+			}
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Fatalf("did not get expected output, diff(-got,+want):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
```
  * (D) a
    - Remove erroneous file.
  * (A) afthelper/afthelper.go
  * (A) afthelper/afthelper_test.go
   -  Add a helper function to take a RIB and determine the set of
      IP address next-hops from the AFT model. This allows us to
      take an input gRIBI entry and determine what next-hop IPs
      it uses, which then can be resolved to connected interfaces.
```
