### PR TITLE
Plumb the gRIBI server -> sysRIB. 

### DIFF
--- a/afthelper/afthelper.go
+++ b/afthelper/afthelper.go
@@ -25,11 +25,11 @@ import (
 // NextHopSummary provides a summary of an next-hop for a particular entry.
 type NextHopSummary struct {
 	// Weight is the share of traffic that the next-hop gets.
-	Weight uint64
+	Weight uint64 `json:"weight"`
 	// Address is the IP address of the next-hop.
-	Address string
+	Address string `json:"address"`
 	// NetworkInstance is the network instance within which the address was resolved.
-	NetworkInstance string
+	NetworkInstance string `json:"network-instance"`
 }
 
 // NextHopAddrsForPrefix unrolls the prefix specified within the network-instance netInst from the

--- a/afthelper/afthelper_test.go
+++ b/afthelper/afthelper_test.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package afthelper
 
 import (

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -205,7 +205,7 @@ func addIPv4Internal(addr string, t testing.TB, wantACK fluent.ProgrammingResult
 	c := fluent.NewClient()
 	ops := []func(){
 		func() {
-			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(1))
+			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.1"))
 		},
 		func() {
 			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithID(42).AddNextHop(1, 1))

--- a/device/device.go
+++ b/device/device.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openconfig/ygot/ygot"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/encoding/prototext"
 
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	spb "github.com/openconfig/gribi/v1/proto/service"
@@ -166,11 +167,13 @@ func New(ctx context.Context, opts ...DevOpt) (*Device, error) {
 		case err != nil:
 			log.Errorf("invalid notifications, %v", err)
 		default:
-			go d.gnmiSrv.TargetUpdate(&gpb.SubscribeResponse{
+			u := &gpb.SubscribeResponse{
 				Response: &gpb.SubscribeResponse_Update{
 					Update: n,
 				},
-			})
+			}
+			log.V(2).Infof("sending gNMI Notification, %s", prototext.Format(u))
+			go d.gnmiSrv.TargetUpdate(u)
 		}
 
 		// server.WithFIBProgrammedCheck()

--- a/device/device.go
+++ b/device/device.go
@@ -21,8 +21,10 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/openconfig/gribigo/aft"
+	"github.com/openconfig/gribigo/afthelper"
 	"github.com/openconfig/gribigo/constants"
 	"github.com/openconfig/gribigo/gnmit"
+	"github.com/openconfig/gribigo/ocrt"
 	"github.com/openconfig/gribigo/server"
 	"github.com/openconfig/gribigo/sysrib"
 	"github.com/openconfig/ygot/ygot"
@@ -138,7 +140,17 @@ func (*tlsCreds) isDevOpt() {}
 func New(ctx context.Context, opts ...DevOpt) (*Device, error) {
 	d := &Device{}
 
-	if jcfg := optDeviceCfg(opts); jcfg != nil {
+	jcfg := optDeviceCfg(opts)
+	switch jcfg {
+	case nil:
+		dev := &ocrt.Device{}
+		dev.GetOrCreateNetworkInstance("DEFAULT").Type = ocrt.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE
+		sr, err := sysrib.NewSysRIB(dev)
+		if err != nil {
+			return nil, fmt.Errorf("cannot build system RIB, %v", err)
+		}
+		d.sysRIB = sr
+	default:
 		sr, err := sysrib.NewSysRIBFromJSON(jcfg)
 		if err != nil {
 			return nil, fmt.Errorf("cannot build system RIB, %v", err)
@@ -168,6 +180,27 @@ func New(ctx context.Context, opts ...DevOpt) (*Device, error) {
 		// here we just write to something that the server has access to.
 	}
 
+	ribAddfn := func(ribs map[string]*aft.RIB, optype constants.OpType, netinst, prefix string) {
+		if optype != constants.Add {
+			// TODO(robjs): handle replace and delete :-)
+			return
+		}
+		nhs, err := afthelper.NextHopAddrsForPrefix(ribs, netinst, prefix)
+		if err != nil {
+			log.Errorf("cannot add netinst:prefix %s:%s to the RIB, %v", netinst, prefix, err)
+			return
+		}
+		nhSum := []*afthelper.NextHopSummary{}
+		for _, nh := range nhs {
+			nhSum = append(nhSum, nh)
+		}
+
+		d.sysRIB.AddRoute(netinst, &sysrib.Route{
+			Prefix:   prefix,
+			NextHops: nhSum,
+		})
+	}
+
 	gr := optGRIBIAddr(opts)
 	gn := optGNMIAddr(opts)
 
@@ -176,7 +209,10 @@ func New(ctx context.Context, opts ...DevOpt) (*Device, error) {
 		return nil, fmt.Errorf("must specific TLS credentials to start a server")
 	}
 
-	gRIBIStop, err := d.startgRIBI(ctx, gr.host, gr.port, creds, server.WithRIBHook(ribHookfn))
+	gRIBIStop, err := d.startgRIBI(ctx, gr.host, gr.port, creds,
+		server.WithPostChangeRIBHook(ribHookfn),
+		server.WithRIBResolvedEntryHook(ribAddfn),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot start gRIBI server, %v", err)
 	}

--- a/device/device_test.go
+++ b/device/device_test.go
@@ -16,15 +16,43 @@ package device
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net"
 	"testing"
 
+	log "github.com/golang/glog"
+	"github.com/google/go-cmp/cmp"
 	"github.com/openconfig/gribigo/compliance"
+	"github.com/openconfig/gribigo/ocrt"
+	"github.com/openconfig/gribigo/sysrib"
 	"github.com/openconfig/gribigo/testcommon"
+	"github.com/openconfig/ygot/ygot"
 )
+
+type ribQuery struct {
+	NetworkInstance string
+	Prefix          *net.IPNet
+}
+
+func jsonDevice() []byte {
+	d := &ocrt.Device{}
+	d.GetOrCreateNetworkInstance("DEFAULT").Type = ocrt.NetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE
+	d.GetOrCreateInterface("eth0").GetOrCreateSubinterface(1).GetOrCreateIpv4().GetOrCreateAddress("192.0.2.1").PrefixLength = ygot.Uint8(31)
+
+	j, err := ygot.Marshal7951(d, nil)
+	if err != nil {
+		panic(fmt.Sprintf("cannot create JSON, %v", err))
+	}
+	return j
+}
 
 func TestDevice(t *testing.T) {
 	devCh := make(chan string, 1)
 	errCh := make(chan error, 1)
+	ribCh := make(chan *ribQuery, 1)
+	ribErrCh := make(chan error)
+	ribResultCh := make(chan []*sysrib.Interface, 1)
 
 	creds, err := TLSCredsFromFile(testcommon.TLSCreds())
 	if err != nil {
@@ -34,17 +62,55 @@ func TestDevice(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
-		d, err := New(ctx, creds)
+		d, err := New(ctx, creds, DeviceConfig(jsonDevice()))
 		if err != nil {
 			errCh <- err
 		}
 		devCh <- d.GRIBIAddr()
-		<-ctx.Done()
+
+		for {
+			select {
+			case qryPfx := <-ribCh:
+				ints, err := d.sysRIB.EgressInterface(qryPfx.NetworkInstance, qryPfx.Prefix)
+				if err != nil {
+					ribErrCh <- err
+				}
+				ribResultCh <- ints
+			case <-ctx.Done():
+				return
+			}
+		}
 	}()
 	select {
 	case err := <-errCh:
 		t.Fatalf("got unexpected error from device, got: %v", err)
 	case addr := <-devCh:
 		compliance.AddIPv4EntryRIBACK(addr, t)
+
+		_, cidr, err := net.ParseCIDR("1.1.1.1/32")
+		if err != nil {
+			t.Fatalf("cannot parse CIDR for destination, err: %v", err)
+		}
+
+		ribCh <- &ribQuery{NetworkInstance: "DEFAULT", Prefix: cidr}
+		select {
+		case err := <-ribErrCh:
+			t.Fatalf("cannot run RIB query, gotErr: %v", err)
+		case got := <-ribResultCh:
+			js, err := json.MarshalIndent(got, "", "  ")
+			if err != nil {
+				t.Fatalf("cannot marshal JSON response, %v", err)
+			}
+			log.Infof("got egress interface, %s", js)
+
+			want := []*sysrib.Interface{{
+				Name:         "eth0",
+				Subinterface: 1,
+			}}
+
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Fatalf("did not get expected egress interface, diff(-got,+want):\n%s", diff)
+			}
+		}
 	}
 }

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -476,6 +476,23 @@ func (n *nextHopEntry) WithNetworkInstance(ni string) *nextHopEntry {
 	return n
 }
 
+// WithIPAddress specifies an IP address to be used for the next-hop. The IP
+// address is resolved within the network instance specified by WithNextHopNetworkInstance.
+func (n *nextHopEntry) WithIPAddress(addr string) *nextHopEntry {
+	n.pb.NextHop.IpAddress = &wpb.StringValue{Value: addr}
+	return n
+}
+
+// WithNextHopNetworkInstance specifies the network instance within which the next-hop
+// should be resolved. If it is not specified, the next-hop is resolved in the network
+// instance that the next-hop is installed in. If no other parameters are specified, the
+// lookup uses the input packet within the specified network instance to determine the
+// next-hop.
+func (n *nextHopEntry) WithNextHopNetworkInstance(ni string) *nextHopEntry {
+	n.pb.NextHop.NetworkInstance = &wpb.StringValue{Value: ni}
+	return n
+}
+
 // TODO(robjs): add additional NextHopEntry fields.
 
 // opproto implements the gRIBIEntry interface, returning a gRIBI AFTOperation. ID


### PR DESCRIPTION
```
commit ca90d3e8384706ade54a518dd444d4b94fb0c18c (HEAD -> dataplane-prod2, origin/dataplane-prod2)
Author: Rob Shakir <robjs@google.com>
Date:   Wed Jun 23 13:05:26 2021 -0700

    Add missing copyright notice.
    
      * (M) afthelper/afthelper_test.go
        - Add missing copyright notice to afthelper_test.go

commit a0661c2149d96a3ba3e94da5675006b735470a9e (dataplane-prod3)
Author: Rob Shakir <robjs@google.com>
Date:   Wed Jun 23 13:02:32 2021 -0700

    Plumb the gRIBI server -> sysRIB.
    
      * (M) compliance/compliance.go
        - Make the compliance test case actually resolve an IPv4
          prefix to an egress interface
      * (M) device/device.go
      * (M) device/device_test.go
        - Connect the gRIBI server to sysRIB so that entries that are
          installed are then installed into the sysRIB when they are
          resolved.
      * (M) fluent/fluent.go
        - Add support
      * (M) server/server.go
        - Rename hooks to be more intuitive.

commit 4391f668ca16d38baa497560e85c39e714a45564
Author: Rob Shakir <robjs@google.com>
Date:   Wed Jun 23 12:03:28 2021 -0700

    Add support for non-connected nexthops to AFT RIB.
    
      * (M) afthelper/afthelper.go
        -  Add JSON marshalling for summary next-hops.
      * (M) sysrib/sysrib.go
      * (M) sysrib/sysrib_test.go
        - Add support for recursing onto non-connected next-hops
          to egress interface.
```