### PR TITLE
Add compliance tests for metadata, different NI NHG.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -544,7 +544,19 @@ func (o *OpResult) String() string {
 	}
 
 	if v := o.OperationID; v != 0 {
-		buf.WriteString(fmt.Sprintf(" AFTOperation { ID: %d, Type: %s, Status: %s }", v, o.Details.Type, o.ProgrammingResult))
+    var key string
+    switch {
+    case o.Details.NextHopIndex != 0:
+      key = fmt.Sprintf("NH %d", o.Details.NextHopIndex)
+    case o.Details.NextHopGroupID != 0:
+      key = fmt.Sprintf("NHG %d", o.Details.NextHopGroupID)
+    case o.Details.IPv4Prefix != "":
+      key = o.Details.IPv4Prefix
+    default:
+      key = "unknown"
+    }
+
+		buf.WriteString(fmt.Sprintf(" AFTOperation { ID: %d, Type: %s, Key: %s, Status: %s }", v, o.Details.Type, key, o.ProgrammingResult))
 	}
 
 	if v := o.SessionParameters; v != nil {

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -455,6 +455,13 @@ func (i *ipv4Entry) WithNextHopGroupNetworkInstance(n string) *ipv4Entry {
 	return i
 }
 
+// WithMetadata specifies a byte slice that is stored as metadata alongside
+// the entry on the gRIBI server.
+func (i *ipv4Entry) WithMetadata(b []byte) *ipv4Entry {
+	i.pb.Ipv4Entry.Metadata = &wpb.BytesValue{Value: b}
+	return i
+}
+
 // opproto implements the gRIBIEntry interface, returning a gRIBI AFTOperation. ID
 // and ElectionID are explicitly not populated such that they can be populated by
 // the function (e.g., AddEntry) to which they are an argument.


### PR DESCRIPTION
```
 * (M) client/client.go
  - Improve string message for OpResults.
 * (M) compliance/compliance.go
  - Add IPv4Entry -> NHG in different NI test - currently skipped
    based on server configuration.
  - Add test for metadata on IPv4Entry.
 * (M) fluent/fluent.go
  - Add fluent function for adding metadata.
```
