### PR TITLE
Do not send election_id = 0.

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -33,6 +33,12 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+// init statically sets the first Election ID used by the compliance tests to 1, since 0
+// is an invalid value.
+func init() {
+	electionID.Store(1)
+}
+
 // electionID is a atomically updated uint64 that we use for the election ID in the tests
 // this ensures that we do not have tests that specify an election ID that is older than
 // the last tests', and thus fail due to the state of the server.


### PR DESCRIPTION
The compliance tests, which handle election ID management, were sending a value of 0,
which is an invalid election ID per the specification.

```
﻿  * (M) compliance/compliance.go
    - Ensure that the compliance tests do not send election_id = 0
      which is an invalid value.
```
