### PR TITLE
Handle nil responses when debugging.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -534,6 +534,9 @@ type OpDetailsResults struct {
 
 // String returns a string for an OpResult for debugging purposes.
 func (o *OpResult) String() string {
+	if o == nil {
+		return "<nil>"
+	}
 	buf := &bytes.Buffer{}
 	buf.WriteString("<")
 	buf.WriteString(fmt.Sprintf("%d (%d nsec):", o.Timestamp, o.Latency))

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1098,3 +1098,27 @@ func TestGet(t *testing.T) {
 		})
 	}
 }
+
+func TestOpResultString(t *testing.T) {
+	tests := []struct {
+		desc     string
+		inResult *OpResult
+		want     string
+	}{{
+		desc:     "nil input",
+		inResult: nil,
+		want:     "<nil>",
+	}, {
+		desc:     "all fields nil",
+		inResult: &OpResult{},
+		want:     "<0 (0 nsec):>",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := tt.inResult.String(); got != tt.want {
+				t.Fatalf("did not get expected string, got: %s, want: %s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
```
﻿  * (M) client/client.go
  * (M) client/client_test.go
    - Ensure that a nil input value is cleanly handled when calling
      String() on a nil OpResult.
```
