### PR TITLE
Add Send method to fluent Get

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/openconfig/gribigo/constants"
 	"github.com/openconfig/gribigo/rib"
 	"github.com/openconfig/gribigo/server"
 	"github.com/openconfig/gribigo/testcommon"
@@ -781,14 +780,16 @@ func TestGet(t *testing.T) {
 		desc string
 		// Operations to perform on the server before we make the request.
 		inOperations []*spb.AFTOperation
-		inGetRequest *GetRequest
+		inGetRequest *spb.GetRequest
 		wantResponse *spb.GetResponse
 		wantErr      bool
 	}{{
 		desc: "empty operations",
-		inGetRequest: &GetRequest{
-			NetworkInstance: server.DefaultNetworkInstanceName,
-			AFT:             constants.All,
+		inGetRequest: &spb.GetRequest{
+			NetworkInstance: &spb.GetRequest_Name{
+				Name: server.DefaultNetworkInstanceName,
+			},
+			Aft: spb.AFTType_ALL,
 		},
 		wantResponse: &spb.GetResponse{},
 	}, {
@@ -802,9 +803,11 @@ func TestGet(t *testing.T) {
 				},
 			},
 		}},
-		inGetRequest: &GetRequest{
-			NetworkInstance: server.DefaultNetworkInstanceName,
-			AFT:             constants.All,
+		inGetRequest: &spb.GetRequest{
+			NetworkInstance: &spb.GetRequest_Name{
+				Name: server.DefaultNetworkInstanceName,
+			},
+			Aft: spb.AFTType_ALL,
 		},
 		wantResponse: &spb.GetResponse{
 			Entry: []*spb.AFTEntry{{
@@ -836,9 +839,11 @@ func TestGet(t *testing.T) {
 				},
 			},
 		}},
-		inGetRequest: &GetRequest{
-			NetworkInstance: server.DefaultNetworkInstanceName,
-			AFT:             constants.All,
+		inGetRequest: &spb.GetRequest{
+			NetworkInstance: &spb.GetRequest_Name{
+				Name: server.DefaultNetworkInstanceName,
+			},
+			Aft: spb.AFTType_ALL,
 		},
 		wantResponse: &spb.GetResponse{
 			Entry: []*spb.AFTEntry{{
@@ -879,9 +884,11 @@ func TestGet(t *testing.T) {
 				},
 			},
 		}},
-		inGetRequest: &GetRequest{
-			NetworkInstance: server.DefaultNetworkInstanceName,
-			AFT:             constants.All,
+		inGetRequest: &spb.GetRequest{
+			NetworkInstance: &spb.GetRequest_Name{
+				Name: server.DefaultNetworkInstanceName,
+			},
+			Aft: spb.AFTType_ALL,
 		},
 		wantResponse: &spb.GetResponse{
 			Entry: []*spb.AFTEntry{{
@@ -905,9 +912,11 @@ func TestGet(t *testing.T) {
 				},
 			},
 		}},
-		inGetRequest: &GetRequest{
-			NetworkInstance: "VRF-FOO",
-			AFT:             constants.All,
+		inGetRequest: &spb.GetRequest{
+			NetworkInstance: &spb.GetRequest_Name{
+				Name: "VRF-FOO",
+			},
+			Aft: spb.AFTType_ALL,
 		},
 		wantResponse: &spb.GetResponse{
 			Entry: []*spb.AFTEntry{{
@@ -939,9 +948,11 @@ func TestGet(t *testing.T) {
 				},
 			},
 		}},
-		inGetRequest: &GetRequest{
-			AllNetworkInstances: true,
-			AFT:                 constants.All,
+		inGetRequest: &spb.GetRequest{
+			NetworkInstance: &spb.GetRequest_All{
+				All: &spb.Empty{},
+			},
+			Aft: spb.AFTType_ALL,
 		},
 		wantResponse: &spb.GetResponse{
 			Entry: []*spb.AFTEntry{{
@@ -964,19 +975,14 @@ func TestGet(t *testing.T) {
 		},
 	}, {
 		desc:         "invalid request - nothing specified",
-		inGetRequest: &GetRequest{},
+		inGetRequest: &spb.GetRequest{},
 		wantErr:      true,
 	}, {
-		desc: "invalid request - both fields specified",
-		inGetRequest: &GetRequest{
-			NetworkInstance:     "foo",
-			AllNetworkInstances: true,
-		},
-		wantErr: true,
-	}, {
 		desc: "invalid request, unsupported AFT",
-		inGetRequest: &GetRequest{
-			NetworkInstance: "foo",
+		inGetRequest: &spb.GetRequest{
+			NetworkInstance: &spb.GetRequest_Name{
+				Name: "foo",
+			},
 		},
 		wantErr: true,
 	}, {
@@ -1006,9 +1012,11 @@ func TestGet(t *testing.T) {
 				},
 			},
 		}},
-		inGetRequest: &GetRequest{
-			NetworkInstance: server.DefaultNetworkInstanceName,
-			AFT:             constants.IPv4,
+		inGetRequest: &spb.GetRequest{
+			NetworkInstance: &spb.GetRequest_Name{
+				Name: server.DefaultNetworkInstanceName,
+			},
+			Aft: spb.AFTType_IPV4,
 		},
 		wantResponse: &spb.GetResponse{
 			Entry: []*spb.AFTEntry{{

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -329,6 +329,11 @@ func (g *gRIBIGet) WithAFT(a AFT) *gRIBIGet {
 	return g
 }
 
+// Send issues Get RPC to the target and returns the results.
+func (g *gRIBIGet) Send() (*spb.GetResponse, error) {
+	return g.parent.c.Get(g.parent.ctx, g.pb)
+}
+
 // Modify wraps methods that trigger operations within the gRIBI Modify RPC.
 func (g *GRIBIClient) Modify() *gRIBIModify {
 	return &gRIBIModify{parent: g}

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -276,7 +276,10 @@ type gRIBIGet struct {
 // been succesfully installed according to the request's ACK type. It can be filtered
 // according to network instance and AFT.
 func (g *GRIBIClient) Get() *gRIBIGet {
-	return &gRIBIGet{parent: g}
+	return &gRIBIGet{
+		parent: g,
+		pb:     &spb.GetRequest{},
+	}
 }
 
 // AllNetworkInstance requests entries from all network instances.


### PR DESCRIPTION
Previously the fluent Get() method was only constructing the Get RPC proto message but was not sending it to the target. This PR adds the support to use the client.Get() to transmit the RPC to target and to return the response to the fluent client.