### PR TITLE
[gribi-compliance-get] Implement tests for Get with checks.

### DIFF
--- a/chk/chk.go
+++ b/chk/chk.go
@@ -240,7 +240,7 @@ func HasRecvClientErrorWithStatus(t testing.TB, err error, want *status.Status, 
 // GetResponseHasEntry checks whether the supplied GetResponse has the gRIBI
 // entry described by the specified want within it. It calls t.Fatalf if no
 // such entry is found.
-func GetResponseHasEntries(t testing.TB, getres *spb.GetResponse, wants []fluent.GRIBIEntry) {
+func GetResponseHasEntries(t testing.TB, getres *spb.GetResponse, wants ...fluent.GRIBIEntry) {
 	// proto.Equal tends to be expensive, so start with building a cache
 	// so that we do not loop each time. We have to do this by network
 	// instance, because each NI has its own namespace for each included
@@ -313,7 +313,5 @@ func GetResponseHasEntries(t testing.TB, getres *spb.GetResponse, wants []fluent
 				t.Fatalf("did not find entry, did not find ipv4: %s, got: %s\n", v.Ipv4, getres)
 			}
 		}
-
 	}
-
 }

--- a/chk/chk_test.go
+++ b/chk/chk_test.go
@@ -431,14 +431,14 @@ func TestGetResponseHasEntries(t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			if tt.expectFatalMsg != "" {
 				got := negtest.ExpectFatal(t, func(t testing.TB) {
-					GetResponseHasEntries(t, tt.inGetRes, tt.inWants)
+					GetResponseHasEntries(t, tt.inGetRes, tt.inWants...)
 				})
 				if !strings.Contains(got, tt.expectFatalMsg) {
 					t.Fatalf("did not get expected fatal message, but test called Fatal, got: %s, want: %s", got, tt.expectFatalMsg)
 				}
 				return
 			}
-			GetResponseHasEntries(t, tt.inGetRes, tt.inWants)
+			GetResponseHasEntries(t, tt.inGetRes, tt.inWants...)
 		})
 	}
 }

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -245,6 +245,21 @@ var (
 		},
 	}, {
 		In: Test{
+			Fn:        makeTestWithACK(GetNHG, fluent.InstalledInRIB),
+			ShortName: "Get for installed NHG - RIB ACK",
+		},
+	}, {
+		In: Test{
+			Fn:        makeTestWithACK(GetIPv4, fluent.InstalledInRIB),
+			ShortName: "Get for installed IPv4 Entry - RIB ACK",
+		},
+	}, {
+		In: Test{
+			Fn:        makeTestWithACK(GetIPv4Chain, fluent.InstalledInRIB),
+			ShortName: "Get for installed chain of entries - RIB ACK",
+		},
+	}, {
+		In: Test{
 			Fn:        makeTestWithACK(GetBenchmarkNH, fluent.InstalledInRIB),
 			ShortName: "Benchmark Get for next-hops",
 		},

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -263,6 +263,30 @@ var (
 			Fn:        makeTestWithACK(GetBenchmarkNH, fluent.InstalledInRIB),
 			ShortName: "Benchmark Get for next-hops",
 		},
+	}, {
+		In: Test{
+			Fn:             makeTestWithACK(GetNH, fluent.InstalledInFIB),
+			ShortName:      "Get for installed NH - FIB ACK",
+			RequiresFIBACK: true,
+		},
+	}, {
+		In: Test{
+			Fn:             makeTestWithACK(GetNHG, fluent.InstalledInFIB),
+			ShortName:      "Get for installed NHG - FIB ACK",
+			RequiresFIBACK: true,
+		},
+	}, {
+		In: Test{
+			Fn:             makeTestWithACK(GetIPv4, fluent.InstalledInFIB),
+			ShortName:      "Get for installed IPv4 Entry - FIB ACK",
+			RequiresFIBACK: true,
+		},
+	}, {
+		In: Test{
+			Fn:             makeTestWithACK(GetIPv4Chain, fluent.InstalledInFIB),
+			ShortName:      "Get for installed chain of entries - FIB ACK",
+			RequiresFIBACK: true,
+		},
 	}}
 )
 

--- a/compliance/get.go
+++ b/compliance/get.go
@@ -61,9 +61,13 @@ func GetNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB
 		WithAFT(fluent.NextHop).
 		Send()
 
-	// TODO(robjs): add checking for get responses, requires new
-	// fluent/check library for this.
-	_, _ = gr, err
+	if err != nil {
+		t.Fatalf("got unexpected error from get, got: %v", err)
+	}
+
+	// Implement check against getresponse contents.
+	_ = gr
+
 }
 
 // TODO(robjs): get NHG

--- a/compliance/get.go
+++ b/compliance/get.go
@@ -72,7 +72,7 @@ func GetNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB
 			WithIPAddress("1.1.1.1"))
 }
 
-// GetNH validates that an installed next-hop-group is returned via the Get RPC.
+// GetNHG validates that an installed next-hop-group is returned via the Get RPC.
 func GetNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB) {
 	ops := []func(){
 		func() {

--- a/compliance/get.go
+++ b/compliance/get.go
@@ -65,20 +65,242 @@ func GetNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB
 		t.Fatalf("got unexpected error from get, got: %v", err)
 	}
 
-	// Implement check against getresponse contents.
-	_ = gr
-
+	chk.GetResponseHasEntries(t, gr,
+		fluent.NextHopEntry().
+			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithIndex(1).
+			WithIPAddress("1.1.1.1"))
 }
 
-// TODO(robjs): get NHG
-// TODO(robjs): get ipv4 entry
+// GetNH validates that an installed next-hop-group is returned via the Get RPC.
+func GetNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB) {
+	ops := []func(){
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopEntry().
+					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithIndex(1).
+					WithIPAddress("1.1.1.1"))
+		},
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopGroupEntry().
+					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithID(1).
+					AddNextHop(1, 1))
+		},
+	}
 
+	res := doModifyOps(c, t, ops, wantACK, false)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopOperation(1).
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopGroupOperation(1).
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	ctx := context.Background()
+	c.Start(ctx, t)
+	defer c.Stop(t)
+	gr, err := c.Get().
+		WithNetworkInstance(server.DefaultNetworkInstanceName).
+		WithAFT(fluent.NextHopGroup).
+		Send()
+
+	if err != nil {
+		t.Fatalf("got unexpected error from get, got: %v", err)
+	}
+
+	chk.GetResponseHasEntries(t, gr,
+		fluent.NextHopGroupEntry().
+			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithID(1).
+			AddNextHop(1, 1),
+	)
+}
+
+// GetIPv4 validates that an installed IPv4 entry is returned via the Get RPC.
+func GetIPv4(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB) {
+	ops := []func(){
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopEntry().
+					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithIndex(1).
+					WithIPAddress("1.1.1.1"))
+		},
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopGroupEntry().
+					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithID(1).
+					AddNextHop(1, 1))
+		},
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.IPv4Entry().
+					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNextHopGroup(1).
+					WithPrefix("42.42.42.42/32"))
+		},
+	}
+
+	res := doModifyOps(c, t, ops, wantACK, false)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopOperation(1).
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopGroupOperation(1).
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithIPv4Operation("42.42.42.42/32").
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	ctx := context.Background()
+	c.Start(ctx, t)
+	defer c.Stop(t)
+	gr, err := c.Get().
+		WithNetworkInstance(server.DefaultNetworkInstanceName).
+		WithAFT(fluent.IPv4).
+		Send()
+
+	if err != nil {
+		t.Fatalf("got unexpected error from get, got: %v", err)
+	}
+
+	chk.GetResponseHasEntries(t, gr,
+		fluent.IPv4Entry().
+			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNextHopGroup(1).
+			WithPrefix("42.42.42.42/32"),
+	)
+}
+
+// GetIPv4Chain validates that Get for all AFTs returns the chain of IPv4Entry->NHG->NH
+// required.
+func GetIPv4Chain(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB) {
+	ops := []func(){
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopEntry().
+					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithIndex(1).
+					WithIPAddress("1.1.1.1"))
+		},
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopGroupEntry().
+					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithID(1).
+					AddNextHop(1, 1))
+		},
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.IPv4Entry().
+					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNextHopGroup(1).
+					WithPrefix("42.42.42.42/32"))
+		},
+	}
+
+	res := doModifyOps(c, t, ops, wantACK, false)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopOperation(1).
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopGroupOperation(1).
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithIPv4Operation("42.42.42.42/32").
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	ctx := context.Background()
+	c.Start(ctx, t)
+	defer c.Stop(t)
+	gr, err := c.Get().
+		WithNetworkInstance(server.DefaultNetworkInstanceName).
+		WithAFT(fluent.AllAFTs).
+		Send()
+
+	if err != nil {
+		t.Fatalf("got unexpected error from get, got: %v", err)
+	}
+
+	chk.GetResponseHasEntries(t, gr,
+		fluent.IPv4Entry().
+			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNextHopGroup(1).
+			WithPrefix("42.42.42.42/32"),
+		fluent.NextHopGroupEntry().
+			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithID(1).
+			AddNextHop(1, 1),
+		fluent.NextHopEntry().
+			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithIndex(1).
+			WithIPAddress("1.1.1.1"),
+	)
+}
+
+// indexAsIPv4 converts a uint32 index into an IP address, using the baseSlashEight argument as the
+// starting point. For example, if an index = 1 is provided with baseSlashEight = 1 the address
+// returned is 1.0.0.1.
 func indexAsIPv4(i uint32, baseSlashEight int) string {
 	ip := make(net.IP, 4)
 	binary.BigEndian.PutUint32(ip, uint32(i)+uint32(baseSlashEight*16777216))
 	return ip.String()
 }
 
+// populateNNHs creates N next-hops based via the client, c, expecting the wanACK back from
+// the server. Errors are reported via the testing.TB provided.
 func populateNNHs(c *fluent.GRIBIClient, n int, wantACK fluent.ProgrammingResult, t testing.TB) {
 	ops := []func(){}
 	for i := 0; i < n; i++ {
@@ -110,6 +332,9 @@ func populateNNHs(c *fluent.GRIBIClient, n int, wantACK fluent.ProgrammingResult
 	chk.HasResultsCache(t, res, wants, chk.IgnoreOperationID())
 }
 
+// GetBenchmarkNH benchmarks the performance of Get populating the server with N next-hop
+// instances and measuring latency of the Get returned by the server. No validation of
+// the returned contents is performed.
 func GetBenchmarkNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB) {
 	for _, i := range []int{10, 100, 1000} {
 		populateNNHs(c, i, wantACK, t)


### PR DESCRIPTION
```

commit 2225a1456cfe8a1222194a33c233a73c57046272
Author: Rob Shakir <rjs@rob.sh>
Date:   Wed Oct 13 07:11:05 2021 -0700

    Implement tests for Get with checks.
    
     * (M) compliance/compliance.go
     * (M) compliance/get.go
      - Add tests for Get for NH, NHG, IPv4 and a chain of entries for
        IPv4 using the Get RPC.
```


<!---GHSTACKOPEN-->
### Stacked PR Chain: gribi-compliance-get
| PR | Title |  Merges Into  |
|:--:|:------|:-------------:|
|#84|[gribi-compliance-get] Add caching for HasResults to improve performance on large result sets.|**N/A**|
|#85|[gribi-compliance-get] Add initial Get tests.|#84|
|#86|[gribi-compliance-get] Add GetResponse check helper function.|#85|
|#87|[gribi-compliance-get] Implement tests for Get with checks.|#86|
|#88|[gribi-compliance-get] Add FIB ACK mode for Get tests.|#87|

<!---GHSTACKCLOSE-->

