### PR TITLE
[gribi-compliance-get] Add FIB ACK mode for Get tests.

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -263,6 +263,30 @@ var (
 			Fn:        makeTestWithACK(GetBenchmarkNH, fluent.InstalledInRIB),
 			ShortName: "Benchmark Get for next-hops",
 		},
+	}, {
+		In: Test{
+			Fn:             makeTestWithACK(GetNH, fluent.InstalledInFIB),
+			ShortName:      "Get for installed NH - FIB ACK",
+			RequiresFIBACK: true,
+		},
+	}, {
+		In: Test{
+			Fn:             makeTestWithACK(GetNHG, fluent.InstalledInFIB),
+			ShortName:      "Get for installed NHG - FIB ACK",
+			RequiresFIBACK: true,
+		},
+	}, {
+		In: Test{
+			Fn:             makeTestWithACK(GetIPv4, fluent.InstalledInFIB),
+			ShortName:      "Get for installed IPv4 Entry - FIB ACK",
+			RequiresFIBACK: true,
+		},
+	}, {
+		In: Test{
+			Fn:             makeTestWithACK(GetIPv4Chain, fluent.InstalledInFIB),
+			ShortName:      "Get for installed chain of entries - FIB ACK",
+			RequiresFIBACK: true,
+		},
 	}}
 )
 


### PR DESCRIPTION
```

commit 33c7a8c1701fa2e14cbb0bff4e04f1bca873143a
Author: Rob Shakir <rjs@rob.sh>
Date:   Wed Oct 13 07:15:34 2021 -0700

    Add FIB ACK mode for Get tests.
```
