### PR TITLE
Add initial compliance tests for election behaviours.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -142,6 +142,7 @@ func handleParams(opts ...Opt) (*clientState, error) {
 	s := &clientState{
 		SessParams: &spb.SessionParameters{},
 	}
+
 	for _, o := range opts {
 		switch v := o.(type) {
 		case *allPrimaryClients:
@@ -158,6 +159,7 @@ func handleParams(opts ...Opt) (*clientState, error) {
 			s.SessParams.AckType = spb.SessionParameters_RIB_AND_FIB_ACK
 		}
 	}
+
 	return s, nil
 }
 

--- a/compliance/compliance_test.go
+++ b/compliance/compliance_test.go
@@ -44,9 +44,15 @@ func TestCompliance(t *testing.T) {
 			c := fluent.NewClient()
 			c.Connection().WithTarget(d.GRIBIAddr())
 
+			sc := fluent.NewClient()
+			sc.Connection().WithTarget(d.GRIBIAddr())
+			opts := []TestOpt{
+				SecondClient(sc),
+			}
+
 			if tt.FatalMsg != "" {
 				if got := negtest.ExpectFatal(t, func(t testing.TB) {
-					tt.In.Fn(c, t)
+					tt.In.Fn(c, t, opts...)
 				}); !strings.Contains(got, tt.FatalMsg) {
 					t.Fatalf("did not get expected fatal error, got: %s, want: %s", got, tt.FatalMsg)
 				}
@@ -55,14 +61,14 @@ func TestCompliance(t *testing.T) {
 
 			if tt.ErrorMsg != "" {
 				if got := negtest.ExpectError(t, func(t testing.TB) {
-					tt.In.Fn(c, t)
+					tt.In.Fn(c, t, opts...)
 				}); !strings.Contains(got, tt.ErrorMsg) {
 					t.Fatalf("did not get expected error, got: %s, want: %s", got, tt.ErrorMsg)
 				}
 			}
 
 			// Any unexpected error will be caught by being called directly on t from the fluent library.
-			tt.In.Fn(c, t)
+			tt.In.Fn(c, t, opts...)
 		})
 	}
 }

--- a/compliance/election.go
+++ b/compliance/election.go
@@ -1,0 +1,124 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compliance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openconfig/gribigo/chk"
+	"github.com/openconfig/gribigo/fluent"
+	"google.golang.org/grpc/codes"
+)
+
+// secondClient is an option that provides for a second gRIBI client to
+// be supplied to a test.
+type secondClient struct {
+	// c is a fluent gRIBI client.
+	c *fluent.GRIBIClient
+}
+
+// IsTestOpt marks secondClient as implementing the TestOpt interface.
+func (*secondClient) IsTestOpt() {}
+
+func SecondClient(c *fluent.GRIBIClient) *secondClient {
+	return &secondClient{c: c}
+}
+
+// TestUnsupportedElectionParams ensures that election parameters that are invalid -
+// currently ALL_PRIMARY and an election ID are reported as an error.
+func TestUnsupportedElectionParams(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
+	defer electionID.Inc()
+	c.Connection().WithInitialElectionID(electionID.Load(), 0).WithRedundancyMode(fluent.AllPrimaryClients)
+	c.Start(context.Background(), t)
+	defer c.Stop(t)
+	c.StartSending(context.Background(), t)
+
+	err := awaitTimeout(context.Background(), c, t, time.Minute)
+	if err == nil {
+		t.Fatalf("did not get expected error from server, got: nil")
+	}
+
+	chk.HasNSendErrors(t, err, 0)
+	chk.HasNRecvErrors(t, err, 1)
+
+	chk.HasRecvClientErrorWithStatus(
+		t,
+		err,
+		fluent.ModifyError().
+			WithCode(codes.FailedPrecondition).
+			WithReason(fluent.UnsupportedParameters).
+			AsStatus(t),
+		chk.AllowUnimplemented(),
+	)
+}
+
+// TestDifferingElectionParameters checks that when a client A is connected with parameters
+// that differ to those that are used by a new client B an error is returned to client B.
+//
+// opts must contain a SecondClient option such that there is a second stub to be used to
+// the device.
+func TestDifferingElectionParameters(c *fluent.GRIBIClient, t testing.TB, opts ...TestOpt) {
+	defer electionID.Inc()
+
+	var clientA, clientB *fluent.GRIBIClient
+	clientA = c
+	for _, o := range opts {
+		if opt, ok := o.(*secondClient); ok {
+			clientB = opt.c
+		}
+	}
+	if clientA == nil || clientB == nil {
+		t.Fatalf("cannot run test with nil clientA or clientB, clients, a: %v, b: %v", clientA, clientB)
+	}
+
+	clientA.Connection().WithInitialElectionID(electionID.Load(), 0).
+		WithRedundancyMode(fluent.ElectedPrimaryClient).
+		WithPersistence()
+	clientA.Start(context.Background(), t)
+	defer clientA.Stop(t)
+	clientA.StartSending(context.Background(), t)
+
+	clientB.Connection().WithInitialElectionID(electionID.Load(), 1).
+		WithRedundancyMode(fluent.ElectedPrimaryClient).
+		WithPersistence().
+		WithFIBACK()
+	clientB.Start(context.Background(), t)
+	defer clientB.Stop(t)
+	clientB.StartSending(context.Background(), t)
+
+	clientAErr := awaitTimeout(context.Background(), clientA, t, time.Minute)
+	if err := clientAErr; err != nil {
+		t.Fatalf("did not expect error from server in client A, got: %v", err)
+	}
+
+	clientBErr := awaitTimeout(context.Background(), clientB, t, time.Minute)
+	if err := clientBErr; err == nil {
+		t.Fatalf("did not get expected error from server, got: %v", err)
+	}
+
+	chk.HasNSendErrors(t, clientBErr, 0)
+	chk.HasNRecvErrors(t, clientBErr, 1)
+
+	chk.HasRecvClientErrorWithStatus(
+		t,
+		clientBErr,
+		fluent.ModifyError().
+			WithCode(codes.FailedPrecondition).
+			WithReason(fluent.ParamsDifferFromOtherClients).
+			AsStatus(t),
+	)
+}

--- a/compliance/get.go
+++ b/compliance/get.go
@@ -31,7 +31,7 @@ import (
 )
 
 // GetNH validates that an installed next-hop is returned via the Get RPC.
-func GetNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB) {
+func GetNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -73,7 +73,7 @@ func GetNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB
 }
 
 // GetNHG validates that an installed next-hop-group is returned via the Get RPC.
-func GetNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB) {
+func GetNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -132,7 +132,7 @@ func GetNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.T
 }
 
 // GetIPv4 validates that an installed IPv4 entry is returned via the Get RPC.
-func GetIPv4(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB) {
+func GetIPv4(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -208,7 +208,7 @@ func GetIPv4(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.
 
 // GetIPv4Chain validates that Get for all AFTs returns the chain of IPv4Entry->NHG->NH
 // required.
-func GetIPv4Chain(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB) {
+func GetIPv4Chain(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -335,7 +335,7 @@ func populateNNHs(c *fluent.GRIBIClient, n int, wantACK fluent.ProgrammingResult
 // GetBenchmarkNH benchmarks the performance of Get populating the server with N next-hop
 // instances and measuring latency of the Get returned by the server. No validation of
 // the returned contents is performed.
-func GetBenchmarkNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB) {
+func GetBenchmarkNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
 	for _, i := range []int{10, 100, 1000} {
 		populateNNHs(c, i, wantACK, t)
 		ctx := context.Background()

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d // indirect
 	github.com/openconfig/ygot v0.11.0
 	go.uber.org/atomic v1.7.0
-	google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d // indirect
+	google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d
 	google.golang.org/grpc v1.37.0
 	google.golang.org/protobuf v1.26.0
 	lukechampine.com/uint128 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -83,7 +83,6 @@ golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
-golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -119,7 +118,6 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 h1:5Beo0mZN8dRzgrMMkDp0jc8YXQKx9DiJ2k1dkvGsn5A=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/server/server.go
+++ b/server/server.go
@@ -465,7 +465,7 @@ func (s *Server) checkParams(id string, p *spb.SessionParameters, gotMsg bool) (
 	}
 
 	cp := &clientParams{
-		FIBAck:       p.GetAckType() == spb.SessionParameters_RIB_ACK,
+		FIBAck:       p.GetAckType() == spb.SessionParameters_RIB_AND_FIB_ACK,
 		ExpectElecID: p.GetRedundancy() == spb.SessionParameters_SINGLE_PRIMARY,
 		Persist:      p.GetPersistence() == spb.SessionParameters_PRESERVE,
 	}


### PR DESCRIPTION
```
  * (M) client/client.go
    - fix some whitespace issues.
  * (M) compliance/compliance.go
  * (M) compliance/get.go
  * (M) compliance/compliance_test.go
    - add support for an argument to tests that allows additional
      parameters to be provided, including a second client to allow
      for election comparisons against another client.
    - add support for calling all tests with a second client option.
  * (A) compliance/election.go
    - add initial election behaviour tests.
    - mismatched parameters, and successful connection.
  * (M) go.mod
  * (M) go.sum
    - go mod tidy
  * (M) server/server.go
  * (M) server/server_test.go
    - fix a bug whereby clients were incorrectly compared for
      consistency and add unit test to capture this.
```
