### PR TITLE
[gribi-masterelect-01] Add tests for electionID++ and electionID--

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -327,6 +327,16 @@ var (
 			Fn:        TestNewElectionIDNoUpdateRejected,
 			ShortName: "Unannounced master operations are rejected",
 		},
+	}, {
+		In: Test{
+			Fn:        TestIncElectionID,
+			ShortName: "Incrementing election ID is honoured, and older IDs are rejected",
+		},
+	}, {
+		In: Test{
+			Fn:        TestDecElectionID,
+			ShortName: "Decrementing election ID is ignored",
+		},
 	}}
 )
 

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -260,9 +260,6 @@ func (g *GRIBIClient) Status(t testing.TB) *client.ClientStatus {
 	return s
 }
 
-// TODO(robjs): add an UpdateElectionID method such that we can set the election ID
-// after it has initially been created.
-
 // gRIBIGet is a container for arguments to the Get RPC.
 type gRIBIGet struct {
 	// parent is a reference to the parent client.
@@ -372,6 +369,18 @@ func (g *gRIBIModify) ReplaceEntry(t testing.TB, entries ...GRIBIEntry) *gRIBIMo
 		t.Fatalf("cannot build modify request, %v", err)
 	}
 	g.parent.c.Q(m)
+	return g
+}
+
+// UpdateElectionID updates the election ID on the gRIBI Modify channel using value provided.
+// The election ID is a uint128 made up of concatenating the low and high uint64 values provided.
+func (g *gRIBIModify) UpdateElectionID(t testing.TB, low, high uint64) *gRIBIModify {
+	g.parent.c.Q(&spb.ModifyRequest{
+		ElectionId: &spb.Uint128{
+			Low:  low,
+			High: high,
+		},
+	})
 	return g
 }
 


### PR DESCRIPTION
```
  * (M) compliance/compliance.go
  * (M) compliance/election.go
    - add test for incrementing election ID explicitly and ensure that
       the new value is honoured.
     - add test for decrementing election ID explicitly and ensure that
       the new value is not honoured.
  * (M) fluent/fluent.go
    - add a method for explicitly updating the election ID on a Modify
      stream.
```

<!---GHSTACKOPEN-->
### Stacked PR Chain: [gribi-masterelect-01]
| PR | Title |  Merges Into  |
|:--:|:------|:-------------:|
|#91|[gribi-masterelect-01] Add tests for matching clients, lower election ID.|**N/A**|
|#92|[gribi-masterelect-01] Add compliance tests for new master, and explicit election ID updates.|#91|
|#93|[gribi-masterelect-01] Add tests for electionID++ and electionID--|#92|

<!---GHSTACKCLOSE-->
