### PR TITLE
Add support for decapsulation of IPinIP to fluent API.

### DIFF
--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	aftpb "github.com/openconfig/gribi/v1/proto/gribi_aft"
+	enums "github.com/openconfig/gribi/v1/proto/gribi_aft/enums"
 	spb "github.com/openconfig/gribi/v1/proto/service"
 	wpb "github.com/openconfig/ygot/proto/ywrapper"
 )
@@ -569,6 +570,32 @@ func (n *nextHopEntry) WithNextHopNetworkInstance(ni string) *nextHopEntry {
 	return n
 }
 
+// DecapsulateHeader represents the enumerated set of headers that can be decapsulated
+// from a packet.
+type DecapsulateHeader int64
+
+const (
+	_ DecapsulateHeader = iota
+	// IPinIP specifies that the header to be decpsulated is an IPv4 header, and is typically
+	// used when IP-in-IP tunnels are created.
+	IPinIP
+)
+
+var (
+	// decapMap translates between the fluent DecapsulateHeader type and the generated
+	// protobuf name.
+	decapMap = map[DecapsulateHeader]enums.OpenconfigAftTypesEncapsulationHeaderType{
+		IPinIP: enums.OpenconfigAftTypesEncapsulationHeaderType_OPENCONFIGAFTTYPESENCAPSULATIONHEADERTYPE_IPV4,
+	}
+)
+
+// WithDecapsulateHeader specifies that the next-hop should apply an action to decapsulate
+// the packet from the specified header, h.
+func (n *nextHopEntry) WithDecapsulateHeader(h DecapsulateHeader) *nextHopEntry {
+	n.pb.NextHop.DecapsulateHeader = decapMap[h]
+	return n
+}
+
 // WithElectionID specifies an explicit election ID that is to be used hen the next hop
 // is programmed in an AFTOperation. The electionID is a uint128 made up of concatenating
 // the low and high uint64 values provided.
@@ -658,7 +685,7 @@ func (n *nextHopGroupEntry) AddNextHop(index, weight uint64) *nextHopGroupEntry 
 	return n
 }
 
-// WithElectionID specifies an explicit election ID that is to be used hen the next hop group
+// WithElectionID specifies an explicit election ID that is to be used when the next hop group
 // is programmed in an AFTOperation. The electionID is a uint128 made up of concatenating
 // the low and high uint64 values provided.
 func (n *nextHopGroupEntry) WithElectionID(low, high uint64) *nextHopGroupEntry {

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	aftpb "github.com/openconfig/gribi/v1/proto/gribi_aft"
+	enums "github.com/openconfig/gribi/v1/proto/gribi_aft/enums"
 	spb "github.com/openconfig/gribi/v1/proto/service"
 	wpb "github.com/openconfig/ygot/proto/ywrapper"
 )
@@ -287,6 +288,31 @@ func TestEntry(t *testing.T) {
 					Id: 42,
 					NextHopGroup: &aftpb.Afts_NextHopGroup{
 						BackupNextHopGroup: &wpb.UintValue{Value: 84},
+					},
+				},
+			},
+		},
+	}, {
+		desc: "next-hop with decap",
+		in:   NextHopEntry().WithNetworkInstance("DEFAULT").WithIndex(1).WithDecapsulateHeader(IPinIP),
+		wantOpProto: &spb.AFTOperation{
+			NetworkInstance: "DEFAULT",
+			Entry: &spb.AFTOperation_NextHop{
+				NextHop: &aftpb.Afts_NextHopKey{
+					Index: 1,
+					NextHop: &aftpb.Afts_NextHop{
+						DecapsulateHeader: enums.OpenconfigAftTypesEncapsulationHeaderType_OPENCONFIGAFTTYPESENCAPSULATIONHEADERTYPE_IPV4,
+					},
+				},
+			},
+		},
+		wantEntryProto: &spb.AFTEntry{
+			NetworkInstance: "DEFAULT",
+			Entry: &spb.AFTEntry_NextHop{
+				NextHop: &aftpb.Afts_NextHopKey{
+					Index: 1,
+					NextHop: &aftpb.Afts_NextHop{
+						DecapsulateHeader: enums.OpenconfigAftTypesEncapsulationHeaderType_OPENCONFIGAFTTYPESENCAPSULATIONHEADERTYPE_IPV4,
 					},
 				},
 			},


### PR DESCRIPTION
```
  * (M) fluent/fluent.go
  * (M) fluent/fluent_test.go
    - Add a fluent option to a next-hop to specify the header to be
      decapsulated from the packet. Currently, this just supports IPinIP
      but can be extended for other headers in the future.
```
