### PR TITLE
Add testcases(TestSameElectionIDFromTwoClients, TestElectionIDAsZero) in compliance test

### DIFF
--- a/chk/chk.go
+++ b/chk/chk.go
@@ -209,6 +209,17 @@ func AllowUnimplemented() *allowUnimplemented {
 	return &allowUnimplemented{}
 }
 
+// ignoreDetails is used to set DetailReason as nil in wanted modifyError
+type ignoreDetails struct{}
+
+// isErrorOpt marks ignoreDetails as an ErrorOpt.
+func (*ignoreDetails) isErrorOpt() {}
+
+// IgnoreDetails set Details as nil in modifyError
+func IgnoreDetails() *ignoreDetails {
+	return &ignoreDetails{}
+}
+
 // HasRecvClientErrorWithStatus checks whether the supplied ClientErr ce contains a status with
 // the code and details set to the values supplied in want.
 //
@@ -223,6 +234,12 @@ func HasRecvClientErrorWithStatus(t testing.TB, err error, want *status.Status, 
 			uProto.Code = int32(codes.Unimplemented)
 			unimpl := status.FromProto(uProto)
 			okMsgs = append(okMsgs, unimpl)
+		}
+		if _, ok := o.(*ignoreDetails); ok {
+			iDetails := proto.Clone(want.Proto()).(*gspb.Status)
+			iDetails.Details = nil
+			igdetails := status.FromProto(iDetails)
+			okMsgs = append(okMsgs, igdetails)
 		}
 	}
 

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -337,6 +337,16 @@ var (
 			Fn:        TestDecElectionID,
 			ShortName: "Decrementing election ID is ignored",
 		},
+	}, {
+		In: Test{
+			Fn:        TestSameElectionIDFromTwoClients,
+			ShortName: "Sending same election ID from two clients",
+		},
+	}, {
+		In: Test{
+			Fn:        TestElectionIDAsZero,
+			ShortName: "Sending election ID as zero",
+		},
 	}}
 )
 

--- a/compliance/election.go
+++ b/compliance/election.go
@@ -522,3 +522,96 @@ func TestDecElectionID(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			AsResult(),
 	)
 }
+
+// TestSameElectionIDFromTwoClients is the test to start 2 clients with same election ID.
+// The client A should be master and client B should be non-master. The AFT operation
+// from the client B should be rejected.
+func TestSameElectionIDFromTwoClients(c *fluent.GRIBIClient, t testing.TB, opts ...TestOpt) {
+	defer electionID.Inc()
+
+	clientA, clientB := clientAB(c, t, opts...)
+
+	clientA.Connection().WithInitialElectionID(electionID.Load(), 0).
+		WithRedundancyMode(fluent.ElectedPrimaryClient).WithPersistence()
+
+	clientA.Start(context.Background(), t)
+	clientA.StartSending(context.Background(), t)
+	defer clientA.Stop(t)
+
+	clientB.Connection().WithInitialElectionID(electionID.Load(), 0).
+		WithRedundancyMode(fluent.ElectedPrimaryClient).WithPersistence()
+
+	clientB.Start(context.Background(), t)
+	clientB.StartSending(context.Background(), t)
+	defer clientB.Stop(t)
+
+	clientA.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(10).WithIPAddress("192.0.2.1"))
+	clientB.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(10).WithIPAddress("192.0.2.1"))
+
+	clientAErr := awaitTimeout(context.Background(), clientA, t, time.Minute)
+	if err := clientAErr; err != nil {
+		t.Fatalf("did not expect error from server in client A, got: %v", err)
+	}
+
+	clientBErr := awaitTimeout(context.Background(), clientB, t, time.Minute)
+	if err := clientBErr; err != nil {
+		t.Fatalf("did not expect error from server in client A, got: %v", err)
+	}
+
+	chk.HasNSendErrors(t, clientAErr, 0)
+	chk.HasNRecvErrors(t, clientAErr, 0)
+	chk.HasNSendErrors(t, clientBErr, 0)
+	chk.HasNRecvErrors(t, clientBErr, 0)
+
+	chk.HasResult(t, clientA.Results(t),
+		fluent.OperationResult().
+			WithCurrentServerElectionID(electionID.Load(), 0).
+			AsResult(),
+	)
+
+	chk.HasResult(t, clientB.Results(t),
+		fluent.OperationResult().
+			WithCurrentServerElectionID(electionID.Load(), 0).
+			AsResult(),
+	)
+
+	chk.HasResult(t, clientA.Results(t),
+		fluent.OperationResult().
+			WithOperationID(1).
+			WithProgrammingResult(fluent.InstalledInRIB).
+			AsResult(),
+	)
+
+	chk.HasResult(t, clientB.Results(t),
+		fluent.OperationResult().
+			WithOperationID(1).
+			WithProgrammingResult(fluent.ProgrammingFailed).
+			AsResult(),
+	)
+}
+
+// TestElectionIDAsZero is the test to send (0, 0) as the election ID
+// The server should respond with RPC error Invalid Argument
+func TestElectionIDAsZero(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
+	c.Connection().WithInitialElectionID(0, 0).WithRedundancyMode(fluent.ElectedPrimaryClient).WithPersistence()
+	c.Start(context.Background(), t)
+	defer c.Stop(t)
+	c.StartSending(context.Background(), t)
+
+	err := awaitTimeout(context.Background(), c, t, time.Minute)
+	if err == nil {
+		t.Fatalf("did not get expected error from server, got: nil")
+	}
+
+	chk.HasNSendErrors(t, err, 0)
+	chk.HasNRecvErrors(t, err, 1)
+
+	chk.HasRecvClientErrorWithStatus(
+		t,
+		err,
+		fluent.ModifyError().
+			WithCode(codes.InvalidArgument).
+			AsStatus(t),
+		chk.IgnoreDetails(),
+	)
+}


### PR DESCRIPTION
We are adding 2 testcases (TestSameElectionIDFromTwoClients and TestElectionIdAsZero) in compliance test. 
TestSameElectionIDFromTwoClients is the test that same the same election Id from 2 clients and 1st client will be master and 2nd will be non-master
TestElectionIdAsZero is the test that client sends (0,0) as the election Id to the server. the server should respond with RPC error invalid argument based on the protobuf. 

Following is the testing log for those 2 testcases.
```
=== RUN   TestCompliance/Sending_same_election_ID_from_two_clients
E0107 16:11:06.680833   66101 client.go:308] got error receiving message, rpc error: code = Canceled desc = grpc: the client connection is closing
E0107 16:11:06.681058   66101 server.go:265] received nil message on Modify channel
E0107 16:11:06.692817   66101 server.go:843] returning failed to client d7b68aec-86cb-4e45-b0c2-1b8b41b42eed (id: low:52), because they are not the elected master (1a23ea26-dbda-4941-b521-73d6d55c8125 is, id: low:52)
=== RUN   TestCompliance/Sending_election_ID_as_zero
E0107 16:11:06.794018   66101 client.go:308] got error receiving message, rpc error: code = Canceled desc = grpc: the client connection is closing
E0107 16:11:06.794032   66101 client.go:308] got error receiving message, rpc error: code = Canceled desc = grpc: the client connection is closing
E0107 16:11:06.794211   66101 server.go:265] received nil message on Modify channel
E0107 16:11:06.794233   66101 server.go:265] received nil message on Modify channel
E0107 16:11:06.801751   66101 client.go:308] got error receiving message, rpc error: code = InvalidArgument desc = client ID ae6d21d6-8599-44aa-88e3-dadad3d8e4a4, zero is an invalid election ID
```