### PR TITLE
Add unit testing for HasRecvClientErrorWithStatus.

### DIFF
--- a/chk/chk.go
+++ b/chk/chk.go
@@ -235,9 +235,9 @@ func HasRecvClientErrorWithStatus(t testing.TB, err error, want *status.Status, 
 	)
 	for _, o := range opts {
 		if _, ok := o.(*allowUnimplemented); ok {
-			uProto := proto.Clone(want.Proto()).(*gspb.Status)
-			uProto.Code = int32(codes.Unimplemented)
-			okMsgs = append(okMsgs, status.FromProto(uProto))
+			okMsgs = append(okMsgs, status.FromProto(&gspb.Status{
+				Code: int32(codes.Unimplemented),
+			}))
 			ignoreUnimplDets = true
 		}
 		if _, ok := o.(*ignoreDetails); ok {

--- a/chk/chk.go
+++ b/chk/chk.go
@@ -234,15 +234,13 @@ func HasRecvClientErrorWithStatus(t testing.TB, err error, want *status.Status, 
 		if _, ok := o.(*allowUnimplemented); ok {
 			uProto := proto.Clone(want.Proto()).(*gspb.Status)
 			uProto.Code = int32(codes.Unimplemented)
-			unimpl := status.FromProto(uProto)
-			okMsgs = append(okMsgs, unimpl)
+			okMsgs = append(okMsgs, status.FromProto(uProto))
 			ignoreUnimplDetails = true
 		}
 		if _, ok := o.(*ignoreDetails); ok {
 			iDetails := proto.Clone(want.Proto()).(*gspb.Status)
 			iDetails.Details = nil
-			igdetails := status.FromProto(iDetails)
-			okMsgs = append(okMsgs, igdetails)
+			okMsgs = append(okMsgs, status.FromProto(iDetails))
 		}
 	}
 

--- a/chk/chk.go
+++ b/chk/chk.go
@@ -218,14 +218,14 @@ func HasRecvClientErrorWithStatus(t testing.TB, err error, want *status.Status, 
 	t.Helper()
 
 	okMsgs := []*status.Status{want}
-	var ignoreDetails bool
+	var ignoreUnimplDetails bool
 	for _, o := range opts {
 		if _, ok := o.(*allowUnimplemented); ok {
 			uProto := proto.Clone(want.Proto()).(*gspb.Status)
 			uProto.Code = int32(codes.Unimplemented)
 			unimpl := status.FromProto(uProto)
 			okMsgs = append(okMsgs, unimpl)
-			ignoreDetails = true
+			ignoreUnimplDetails = true
 		}
 	}
 
@@ -243,11 +243,9 @@ func HasRecvClientErrorWithStatus(t testing.TB, err error, want *status.Status, 
 				ns.Message = "" // blank out message so that we don't compare it.
 			}
 
-			if ignoreDetails {
+			if ignoreUnimplDetails && wo.Code() == codes.Unimplemented {
 				ns.Details = nil
 			}
-
-			fmt.Printf("compare %v (%T) and %+v (%T)\n", ns, ns, wo.Proto(), wo)
 
 			if proto.Equal(ns, wo.Proto()) {
 				found = true

--- a/chk/chk.go
+++ b/chk/chk.go
@@ -229,18 +229,22 @@ func HasRecvClientErrorWithStatus(t testing.TB, err error, want *status.Status, 
 	t.Helper()
 
 	okMsgs := []*status.Status{want}
-	var ignoreUnimplDetails bool
+	var (
+		ignoreUnimplDets bool
+		ignoreDets       bool
+	)
 	for _, o := range opts {
 		if _, ok := o.(*allowUnimplemented); ok {
 			uProto := proto.Clone(want.Proto()).(*gspb.Status)
 			uProto.Code = int32(codes.Unimplemented)
 			okMsgs = append(okMsgs, status.FromProto(uProto))
-			ignoreUnimplDetails = true
+			ignoreUnimplDets = true
 		}
 		if _, ok := o.(*ignoreDetails); ok {
 			iDetails := proto.Clone(want.Proto()).(*gspb.Status)
 			iDetails.Details = nil
 			okMsgs = append(okMsgs, status.FromProto(iDetails))
+			ignoreDets = true
 		}
 	}
 
@@ -258,7 +262,7 @@ func HasRecvClientErrorWithStatus(t testing.TB, err error, want *status.Status, 
 				ns.Message = "" // blank out message so that we don't compare it.
 			}
 
-			if ignoreUnimplDetails && wo.Code() == codes.Unimplemented {
+			if ignoreUnimplDets && wo.Code() == codes.Unimplemented || ignoreDets {
 				ns.Details = nil
 			}
 

--- a/chk/chk_test.go
+++ b/chk/chk_test.go
@@ -517,7 +517,7 @@ func TestHasRecvClientErrorWithStatus(t *testing.T) {
 			}
 			return s
 		}(),
-		expectFatalMsg: `client does not have receive error with status code:3  message:"bad argument"  details:{[type.googleapis.com/gribi.ModifyRPCErrorDetails]:{reason:ELECTION_ID_IN_ALL_PRIMARY}}`,
+		expectFatalMsg: `client does not have receive error with status code:3 message:"bad argument" details:{[type.googleapis.com/gribi.ModifyRPCErrorDetails]:{reason:ELECTION_ID_IN_ALL_PRIMARY}}`,
 	}, {
 		desc: "allow unimplemented specified",
 		inError: &client.ClientErr{

--- a/chk/chk_test.go
+++ b/chk/chk_test.go
@@ -517,7 +517,7 @@ func TestHasRecvClientErrorWithStatus(t *testing.T) {
 			}
 			return s
 		}(),
-		expectFatalMsg: `client does not have receive error with status code:3 message:"bad argument" details:{[type.googleapis.com/gribi.ModifyRPCErrorDetails]:{reason:ELECTION_ID_IN_ALL_PRIMARY}}`,
+		expectFatalMsg: `client does not have receive error with status code:3`,
 	}, {
 		desc: "allow unimplemented specified",
 		inError: &client.ClientErr{

--- a/chk/chk_test.go
+++ b/chk/chk_test.go
@@ -542,6 +542,21 @@ func TestHasRecvClientErrorWithStatus(t *testing.T) {
 		}(),
 		inWant: status.New(codes.InvalidArgument, ""),
 		inOpts: []ErrorOpt{AllowUnimplemented()},
+	}, {
+		desc: "mismatched details specified but ignored",
+		inError: func() error {
+			s, err := status.New(codes.InvalidArgument, "bad argument").WithDetails(&spb.ModifyRPCErrorDetails{
+				Reason: spb.ModifyRPCErrorDetails_MODIFY_NOT_ALLOWED,
+			})
+			if err != nil {
+				panic("invalid generated error")
+			}
+			return &client.ClientErr{
+				Recv: []error{s.Err()},
+			}
+		}(),
+		inWant: status.New(codes.InvalidArgument, "bad argument"),
+		inOpts: []ErrorOpt{IgnoreDetails()},
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
```
    Add unit test for IgnoreDetails.
    
      * (M) chk/chk.go
      * (M) chk/chk_test.go
        - Fix implementation of IgnoreDetails to ensure that it allows
          details received from the server to be ignored rather than
          solely from the client.
        - Add unit test.
```

```
    Ignore details when chk.AllowUnimplemented() is specified.
    
      * (M) chk/chk.go
        - when chk.AllowUnimplemented() is specified, details of the error
          (which hasn't been explcitly implemented) are still checked -
          change the implementation to explicitly not require details to
          match in these cases.
      * (M) chk/chk_test.go
        - Add unit testing for HasRecvErrorWithStatus.
```
