### PR TITLE
Add support for Flush in client.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1059,3 +1059,42 @@ func (c *Client) Get(ctx context.Context, sreq *spb.GetRequest) (*spb.GetRespons
 	}
 	return result, nil
 }
+
+// Flush implements the gRIBI Flush RPC.
+func (c *Client) Flush(ctx context.Context, req *spb.FlushRequest) (*spb.FlushResponse, error) {
+	if req == nil {
+		return nil, errors.New("flush request cannot be nil")
+	}
+
+	switch t := req.GetNetworkInstance().(type) {
+	case *spb.FlushRequest_All:
+	case *spb.FlushRequest_Name:
+		if t.Name == "" {
+			return nil, errors.New("cannot specify an empty network instance name")
+		}
+	}
+
+	if req.GetElection() == nil && c.state.ElectionID != nil {
+		return nil, fmt.Errorf("must specify an election behaviour for a SINGLE_PRIMARY client")
+	}
+
+	switch t := req.GetElection().(type) {
+	case *spb.FlushRequest_Id:
+		if c.state.SessParams == nil || c.state.SessParams.Redundancy != spb.SessionParameters_SINGLE_PRIMARY {
+			return nil, fmt.Errorf("invalid to specify an election ID when the client is not in SINGLE_PRIMARY mode")
+		}
+	case *spb.FlushRequest_Override:
+		if !t.Override {
+			return nil, fmt.Errorf("invalid override value set to false")
+		}
+		if c.state.SessParams == nil || c.state.SessParams.Redundancy != spb.SessionParameters_SINGLE_PRIMARY {
+			return nil, fmt.Errorf("cannot override election ID when the client is in SINGLE_PRIMARY mode")
+		}
+	}
+
+	res, err := c.c.Flush(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("received error from server, %v", err)
+	}
+	return res, nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -1094,7 +1094,8 @@ func (c *Client) Flush(ctx context.Context, req *spb.FlushRequest) (*spb.FlushRe
 
 	res, err := c.c.Flush(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("received error from server, %v", err)
+		// return err directly here so that the client can receive the type of error.
+		return nil, err
 	}
 	return res, nil
 }

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -352,6 +352,26 @@ var (
 			Fn:        TestElectionIDAsZero,
 			ShortName: "Sending election ID as zero",
 		},
+	}, {
+		In: Test{
+			Fn:        makeTestWithACK(FlushFromMasterDefaultNI, fluent.InstalledInRIB),
+			ShortName: "Flush of all entries in default NI by elected master",
+		},
+	}, {
+		In: Test{
+			Fn:        makeTestWithACK(FlushFromNonMasterDefaultNI, fluent.InstalledInRIB),
+			ShortName: "Flush from non-elected master is ignored",
+		},
+	}, {
+		In: Test{
+			Fn:        makeTestWithACK(FlushFromOverrideDefaultNI, fluent.InstalledInRIB),
+			ShortName: "Flush from client overriding election is honoured",
+		},
+	}, {
+		In: Test{
+			Fn:        makeTestWithACK(FlushOfSpecificNI, fluent.InstalledInRIB),
+			ShortName: "Flush to specific network instance is honoured",
+		},
 	}}
 )
 

--- a/compliance/flush.go
+++ b/compliance/flush.go
@@ -1,0 +1,261 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package compliance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openconfig/gribigo/chk"
+	"github.com/openconfig/gribigo/constants"
+	"github.com/openconfig/gribigo/fluent"
+	"github.com/openconfig/gribigo/server"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// FlushFromMasterDefaultNI programs a chain of entries into the default NI with the
+// specified wantACK mode and then issues a Flush towards the server using the current
+// master's election ID. It validates that no entries remain in the default network
+// instance using the Get RPC.
+func FlushFromMasterDefaultNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	addFlushEntriesToNI(c, server.DefaultNetworkInstanceName, wantACK, t)
+
+	// addFlushEntriesToNI increments the election ID so to check with the current value,
+	// we need to subtract one from the current election ID.
+	curID := electionID.Load() - 1
+
+	ctx := context.Background()
+	c.Start(ctx, t)
+	defer c.Stop(t)
+
+	fr, err := c.Flush().
+		WithElectionID(curID, 0).
+		WithAllNetworkInstances().
+		Send()
+	switch {
+	case err != nil:
+		t.Fatalf("got unexpected error from flush, got: %v", err)
+	case fr == nil:
+		t.Fatalf("got nil response from flush, got: %v", fr)
+	}
+
+	checkNIHasNEntries(ctx, c, server.DefaultNetworkInstanceName, 0, t)
+}
+
+// FlushFromOverrideDefaultNI programs a chain of entries into the default NI with the
+// specified wantACK mode, and then issues a Flush towards the server specifying that
+// the election ID should be overridden and ensures that entries are removed using the
+// Get RPC.
+func FlushFromOverrideDefaultNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	addFlushEntriesToNI(c, server.DefaultNetworkInstanceName, wantACK, t)
+
+	ctx := context.Background()
+	c.Start(ctx, t)
+	defer c.Stop(t)
+
+	fr, err := c.Flush().
+		WithElectionOverride().
+		WithAllNetworkInstances().
+		Send()
+	switch {
+	case err != nil:
+		t.Fatalf("got unexpected error from flush, got: %v", err)
+	case fr == nil:
+		t.Fatalf("got nil response from flush, got: %v", fr)
+	}
+
+	checkNIHasNEntries(ctx, c, server.DefaultNetworkInstanceName, 0, t)
+}
+
+// FlushFromNonMasterDefaultNI sends a Flush to the server using an old election ID
+// and  validates that the programmed chain of entries are not removed form the
+// default NI using the Get RPC.
+func FlushFromNonMasterDefaultNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	addFlushEntriesToNI(c, server.DefaultNetworkInstanceName, wantACK, t)
+
+	// addFlushEntriesToNI increments the election ID so to check with the current value,
+	// we need to subtract two to ensure that we are not the current master.
+	curID := electionID.Load() - 2
+
+	ctx := context.Background()
+	c.Start(ctx, t)
+	defer c.Stop(t)
+
+	_, flushErr := c.Flush().
+		WithElectionID(curID, 0).
+		WithAllNetworkInstances().
+		Send()
+	if flushErr == nil {
+		t.Fatalf("did not get expected error from flush, got: %v", flushErr)
+	}
+
+	s, ok := status.FromError(flushErr)
+	if !ok {
+		t.Fatalf("received invalid error from server, got: %v", flushErr)
+	}
+	if got, want := s.Code(), codes.FailedPrecondition; got != want {
+		t.Fatalf("did not get expected error from server, got code: %s (error: %v), want: %s", got, flushErr, want)
+	}
+
+	checkNIHasNEntries(ctx, c, server.DefaultNetworkInstanceName, 3, t)
+}
+
+// FlushOfSpecificNI programs entries into two network-instances, the default and a named
+// L3VRF. It subsequently issues a Flush RPC and ensures that entries that are within the
+// flushed network instance (the default) are removed, but the others are preserved.
+func FlushOfSpecificNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	// TODO(robjs): we need to initialise the server with >1 network instance.
+	t.Skip()
+
+	vrfName := "TEST-VRF"
+
+	addFlushEntriesToNI(c, server.DefaultNetworkInstanceName, wantACK, t)
+	addFlushEntriesToNI(c, vrfName, wantACK, t)
+
+	// addFlushEntriesToNI increments the election ID so to check with the current value,
+	// we need to subtract one from the current election ID.
+	curID := electionID.Load() - 1
+
+	ctx := context.Background()
+	c.Start(ctx, t)
+	defer c.Stop(t)
+
+	fr, err := c.Flush().
+		WithElectionID(curID, 0).
+		WithNetworkInstance(server.DefaultNetworkInstanceName).
+		Send()
+	switch {
+	case err != nil:
+		t.Fatalf("got unexpected error from flush, got: %v", err)
+	case fr == nil:
+		t.Fatalf("got nil response from flush, got: %v", fr)
+	}
+
+	checkNIHasNEntries(ctx, c, server.DefaultNetworkInstanceName, 0, t)
+	checkNIHasNEntries(ctx, c, vrfName, 3, t)
+}
+
+// FlushOfAllNIs programs entries in two network instances - the default and a
+// named VRF and ensures that entries are removed from both when the Flush specifies
+// that all network instances are to be removed.
+func FlushOfAllNIs(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	// TODO(robjs): we need to initialise the server with >1 network instance.
+	t.Skip()
+
+	vrfName := "TEST-VRF"
+
+	addFlushEntriesToNI(c, server.DefaultNetworkInstanceName, wantACK, t)
+	addFlushEntriesToNI(c, vrfName, wantACK, t)
+
+	// addFlushEntriesToNI increments the election ID so to check with the current value,
+	// we need to subtract one from the current election ID.
+	curID := electionID.Load() - 1
+
+	ctx := context.Background()
+	c.Start(ctx, t)
+	defer c.Stop(t)
+
+	fr, err := c.Flush().
+		WithElectionID(curID, 0).
+		WithAllNetworkInstances().
+		Send()
+	switch {
+	case err != nil:
+		t.Fatalf("got unexpected error from flush, got: %v", err)
+	case fr == nil:
+		t.Fatalf("got nil response from flush, got: %v", fr)
+	}
+
+	checkNIHasNEntries(ctx, c, server.DefaultNetworkInstanceName, 0, t)
+	checkNIHasNEntries(ctx, c, vrfName, 0, t)
+}
+
+// addFlushEntriesToNI is a helper that programs a chain of IPv4->NHG->NH entries
+// into the specified niName network-instance, with the specified wantACK behaviour.
+// It validates that the entries were installed from the returned Modify results.
+func addFlushEntriesToNI(c *fluent.GRIBIClient, niName string, wantACK fluent.ProgrammingResult, t testing.TB) {
+	t.Helper()
+	ops := []func(){
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopEntry().
+					WithNetworkInstance(niName).
+					WithIndex(1).
+					WithIPAddress("1.1.1.1"))
+		},
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.NextHopGroupEntry().
+					WithNetworkInstance(niName).
+					WithID(1).
+					AddNextHop(1, 1))
+		},
+		func() {
+			c.Modify().AddEntry(t,
+				fluent.IPv4Entry().
+					WithNetworkInstance(niName).
+					WithNextHopGroup(1).
+					WithPrefix("42.42.42.42/32"))
+		},
+	}
+
+	res := doModifyOps(c, t, ops, wantACK, false)
+
+	// validate that our entries were installed correctly.
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopOperation(1).
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopGroupOperation(1).
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithIPv4Operation("42.42.42.42/32").
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+}
+
+// checkNIHasNEntries uses the Get RPC to validate that the network instance named ni
+// contains want (an integer) entries.
+func checkNIHasNEntries(ctx context.Context, c *fluent.GRIBIClient, ni string, want int, t testing.TB) {
+	t.Helper()
+	gr, err := c.Get().
+		WithNetworkInstance(ni).
+		WithAFT(fluent.AllAFTs).
+		Send()
+
+	if err != nil {
+		t.Fatalf("got unexpected error from get, got: %v", err)
+	}
+
+	if got := len(gr.GetEntry()); got != want {
+		t.Fatalf("network instance %s has entries, got: %d, wanted:%d\nentries:\n%v", ni, got, want, gr)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1071,3 +1071,9 @@ func NewFake(opt ...ServerOpt) *FakeServer {
 func (f *FakeServer) InjectRIB(r *rib.RIB) {
 	f.Server.masterRIB = r
 }
+
+// InjectElectionID allows a client to set an initial election ID on the server as
+// though it was received from the client.
+func (f *FakeServer) InjectElectionID(id *spb.Uint128) {
+	f.Server.curElecID = id
+}


### PR DESCRIPTION
```
  * (M) client/client.go
  * (M) client/client_test.go
    - Add support for the Flush RPC to be issued by a client.
  * (M) server/server.go
    - Add support for the FakeServer injecting an election ID to allow
      for testing of SINGLE_PRIMARY cases outside of setting up the
      server.
```
