### PR TITLE
Address compliance test failures against emulated nodes.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1088,7 +1088,7 @@ func (c *Client) Flush(ctx context.Context, req *spb.FlushRequest) (*spb.FlushRe
 			return nil, fmt.Errorf("invalid override value set to false")
 		}
 		if c.state.SessParams == nil || c.state.SessParams.Redundancy != spb.SessionParameters_SINGLE_PRIMARY {
-			return nil, fmt.Errorf("cannot override election ID when the client is in SINGLE_PRIMARY mode")
+			return nil, fmt.Errorf("cannot override election ID when the client is in ALL_PRIMARY mode")
 		}
 	}
 

--- a/cmd/ccli/ccli_test.go
+++ b/cmd/ccli/ccli_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openconfig/gribigo/compliance"
 	"github.com/openconfig/gribigo/fluent"
 	"github.com/openconfig/gribigo/negtest"
+	"github.com/openconfig/gribigo/server"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
@@ -42,6 +43,7 @@ var (
 	initialElectionID = flag.Uint("initial_electionid", 0, "initial election ID to be used")
 	skipFIBACK        = flag.Bool("skip_fiback", false, "skip tests that rely on FIB ACK")
 	skipSrvReorder    = flag.Bool("skip_reordering", false, "skip tests that rely on server side transaction reordering")
+	defaultNIName     = flag.String("default_ni_name", server.DefaultNetworkInstanceName, "default network instance name to be used for the server")
 )
 
 // flagCred implements credentials.PerRPCCredentials by populating the
@@ -70,6 +72,8 @@ func TestCompliance(t *testing.T) {
 	if *initialElectionID != 0 {
 		compliance.SetElectionID(uint64(*initialElectionID))
 	}
+
+	compliance.SetDefaultNetworkInstanceName(*defaultNIName)
 
 	dialOpts := []grpc.DialOption{grpc.WithBlock()}
 	if *insecure {

--- a/cmd/ccli/ccli_test.go
+++ b/cmd/ccli/ccli_test.go
@@ -129,6 +129,9 @@ func TestCompliance(t *testing.T) {
 
 			// Any unexpected error will be caught by being called directly on t from the fluent library.
 			tt.In.Fn(c, t)
+
+			// before moving on to the next test, explicitly flush the contents of the gRIBI server's RIB.
+			compliance.FlushServer(c, t)
 		})
 	}
 }

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -544,8 +544,6 @@ func AddIPv4EntryRandom(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			AsResult(),
 		chk.IgnoreOperationID(),
 	)
-
-	// TODO(robjs): add gNMI subscription using generated telemetry library.
 }
 
 // AddIPv4Metadata adds an IPv4 Entry (and its dependencies) with metadata alongside the
@@ -745,9 +743,6 @@ func ImplicitReplaceNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, 
 			WithProgrammingResult(wantACK).
 			AsResult())
 
-	// TODO(robjs): validate that the entry was actually updated - currently this just checks
-	// the gRIBI API logic, but we should validate via AFT telemetry or Get that the RIB was
-	// actually updated.
 }
 
 // ImplicitReplaceNHG performs two add operations for the same NextHopGroup entry, validating that the
@@ -815,8 +810,6 @@ func ImplicitReplaceNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult,
 			WithOperationType(constants.Add).
 			WithProgrammingResult(wantACK).
 			AsResult())
-
-	// TODO(robjs): add validation that the entry was actually updated.
 }
 
 // ImplicitReplaceIPv4Entry performs two add operations for the same NextHopGroup entry, validating that the
@@ -912,8 +905,6 @@ func ImplicitReplaceIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingR
 			WithOperationType(constants.Add).
 			WithProgrammingResult(wantACK).
 			AsResult())
-
-	// TODO(robjs): add validation that the entry was actually updated.
 }
 
 // ReplaceMissingNH validates that an operation for a next-hop entry that does not exist

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -50,6 +50,17 @@ func SetElectionID(v uint64) {
 	electionID.Store(v)
 }
 
+// defaultNetworkInstance name is the string name of the default network instance
+// on the server. It can be overridden by tests that have pushed a configuration
+// to a server where they have specified a value for the default network instance.
+var defaultNetworkInstanceName = server.DefaultNetworkInstanceName
+
+// SetDefaultNetworkInstanceName allows an external caler to specify a network
+// instance name to be used for the default network instance.
+func SetDefaultNetworkInstanceName(n string) {
+	defaultNetworkInstanceName = n
+}
+
 // Test describes a test within the compliance library.
 type Test struct {
 	// Fn is the function to be run for a test. Tests must not error if additional
@@ -434,13 +445,13 @@ func ModifyConnectionSinglePrimaryPreserve(c *fluent.GRIBIClient, t testing.TB, 
 func AddIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
 	ops := []func(){
 		func() {
-			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.1"))
+			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.1"))
 		},
 		func() {
-			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithID(42).AddNextHop(1, 1))
+			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithNetworkInstance(defaultNetworkInstanceName).WithID(42).AddNextHop(1, 1))
 		},
 		func() {
-			c.Modify().AddEntry(t, fluent.IPv4Entry().WithPrefix("1.1.1.1/32").WithNetworkInstance(server.DefaultNetworkInstanceName).WithNextHopGroup(42))
+			c.Modify().AddEntry(t, fluent.IPv4Entry().WithPrefix("1.1.1.1/32").WithNetworkInstance(defaultNetworkInstanceName).WithNextHopGroup(42))
 		},
 	}
 
@@ -474,13 +485,13 @@ func AddIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t tes
 func AddIPv4EntryRandom(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 	ops := []func(){
 		func() {
-			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(1))
+			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(1))
 		},
 		func() {
-			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithID(42).AddNextHop(1, 1))
+			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithNetworkInstance(defaultNetworkInstanceName).WithID(42).AddNextHop(1, 1))
 		},
 		func() {
-			c.Modify().AddEntry(t, fluent.IPv4Entry().WithPrefix("1.1.1.1/32").WithNetworkInstance(server.DefaultNetworkInstanceName).WithNextHopGroup(42))
+			c.Modify().AddEntry(t, fluent.IPv4Entry().WithPrefix("1.1.1.1/32").WithNetworkInstance(defaultNetworkInstanceName).WithNextHopGroup(42))
 		},
 	}
 
@@ -524,12 +535,12 @@ func AddIPv4Metadata(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 		func() {
 			c.Modify().AddEntry(t, fluent.IPv4Entry().
 				WithPrefix("1.1.1.1/32").
-				WithNetworkInstance(server.DefaultNetworkInstanceName).
+				WithNetworkInstance(defaultNetworkInstanceName).
 				WithNextHopGroup(1).
 				WithMetadata([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
 			)
-			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithID(1).WithNetworkInstance(server.DefaultNetworkInstanceName).AddNextHop(1, 1))
-			c.Modify().AddEntry(t, fluent.NextHopEntry().WithIndex(1).WithNetworkInstance(server.DefaultNetworkInstanceName).WithIPAddress("2.2.2.2"))
+			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithID(1).WithNetworkInstance(defaultNetworkInstanceName).AddNextHop(1, 1))
+			c.Modify().AddEntry(t, fluent.NextHopEntry().WithIndex(1).WithNetworkInstance(defaultNetworkInstanceName).WithIPAddress("2.2.2.2"))
 		},
 	}
 
@@ -571,7 +582,7 @@ func AddIPv4EntryDifferentNINHG(c *fluent.GRIBIClient, wantACK fluent.Programmin
 				WithPrefix("1.1.1.1/32").
 				WithNetworkInstance("NON-DEFAULT").
 				WithNextHopGroup(1).
-				WithNextHopGroupNetworkInstance(server.DefaultNetworkInstanceName))
+				WithNextHopGroupNetworkInstance(defaultNetworkInstanceName))
 			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithID(1).AddNextHop(1, 1))
 			c.Modify().AddEntry(t, fluent.NextHopEntry().WithIndex(1).WithIPAddress("2.2.2.2"))
 		},
@@ -649,10 +660,10 @@ func doModifyOps(c *fluent.GRIBIClient, t testing.TB, ops []func(), wantACK flue
 func AddUnreferencedNextHopGroup(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
 	ops := []func(){
 		func() {
-			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.1"))
+			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.1"))
 		},
 		func() {
-			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithID(42).AddNextHop(1, 1))
+			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithNetworkInstance(defaultNetworkInstanceName).WithID(42).AddNextHop(1, 1))
 		},
 	}
 
@@ -681,14 +692,14 @@ func ImplicitReplaceNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, 
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(1).
 					WithIPAddress("192.0.2.1"))
 		},
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(1).
 					WithIPAddress("192.0.2.2"))
 		},
@@ -726,27 +737,27 @@ func ImplicitReplaceNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult,
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(1).
 					WithIPAddress("192.0.2.1"))
 
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(2).
 					WithIPAddress("192.0.2.2"))
 
 			c.Modify().AddEntry(t,
 				fluent.NextHopGroupEntry().
 					WithID(1).
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					AddNextHop(1, 1))
 		},
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopGroupEntry().
 					WithID(1).
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					AddNextHop(2, 1))
 		},
 	}
@@ -795,39 +806,39 @@ func ImplicitReplaceIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingR
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(1).
 					WithIPAddress("192.0.2.1"))
 
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(2).
 					WithIPAddress("192.0.2.1"))
 
 			c.Modify().AddEntry(t,
 				fluent.NextHopGroupEntry().
 					WithID(1).
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					AddNextHop(1, 1))
 
 			c.Modify().AddEntry(t,
 				fluent.NextHopGroupEntry().
 					WithID(2).
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					AddNextHop(2, 1))
 
 			c.Modify().AddEntry(t,
 				fluent.IPv4Entry().
 					WithPrefix("1.0.0.0/8").
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithNextHopGroup(1))
 		},
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.IPv4Entry().
 					WithPrefix("1.0.0.0/8").
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithNextHopGroup(2))
 		},
 	}
@@ -892,7 +903,7 @@ func ReplaceMissingNH(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 		func() {
 			c.Modify().ReplaceEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(42))
 		},
 	}
@@ -916,12 +927,12 @@ func ReplaceMissingNHG(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			// Make sure that our replace does not get rejected because of a missing reference.
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(42))
 
 			c.Modify().ReplaceEntry(t,
 				fluent.NextHopGroupEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithID(42).
 					AddNextHop(42, 1))
 		},
@@ -929,7 +940,7 @@ func ReplaceMissingNHG(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			// Remove the NH we added.
 			c.Modify().DeleteEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(42))
 		},
 	}
@@ -969,18 +980,18 @@ func ReplaceMissingIPv4Entry(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) 
 
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(42))
 
 			c.Modify().AddEntry(t,
 				fluent.NextHopGroupEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithID(42).
 					AddNextHop(42, 1))
 
 			c.Modify().ReplaceEntry(t,
 				fluent.IPv4Entry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithPrefix("192.0.2.1/32").
 					WithNextHopGroup(42))
 		},
@@ -989,12 +1000,12 @@ func ReplaceMissingIPv4Entry(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) 
 
 			c.Modify().DeleteEntry(t,
 				fluent.NextHopGroupEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithID(42))
 
 			c.Modify().DeleteEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(42))
 		},
 	}
@@ -1062,10 +1073,10 @@ func ReplaceMissingIPv4Entry(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) 
 // baseTopologyEntries creates the entries shown in the diagram above using
 // separate ModifyRequests for each entry.
 func baseTopologyEntries(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
-	c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.3"))
-	c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(2).WithIPAddress("192.0.2.5"))
-	c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithID(1).AddNextHop(1, 1).AddNextHop(2, 1))
-	c.Modify().AddEntry(t, fluent.IPv4Entry().WithPrefix("1.0.0.0/8").WithNetworkInstance(server.DefaultNetworkInstanceName).WithNextHopGroup(1))
+	c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.3"))
+	c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(2).WithIPAddress("192.0.2.5"))
+	c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithNetworkInstance(defaultNetworkInstanceName).WithID(1).AddNextHop(1, 1).AddNextHop(2, 1))
+	c.Modify().AddEntry(t, fluent.IPv4Entry().WithPrefix("1.0.0.0/8").WithNetworkInstance(defaultNetworkInstanceName).WithNextHopGroup(1))
 }
 
 // validateBaseEntries checks that the entries in the base topology are correctly
@@ -1111,10 +1122,10 @@ func AddIPv4ToMultipleNHsSingleRequest(c *fluent.GRIBIClient, wantACK fluent.Pro
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
-				fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.3"),
-				fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(2).WithIPAddress("192.0.2.5"),
-				fluent.NextHopGroupEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithID(1).AddNextHop(1, 1).AddNextHop(2, 1),
-				fluent.IPv4Entry().WithPrefix("1.0.0.0/8").WithNetworkInstance(server.DefaultNetworkInstanceName).WithNextHopGroup(1))
+				fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.3"),
+				fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(2).WithIPAddress("192.0.2.5"),
+				fluent.NextHopGroupEntry().WithNetworkInstance(defaultNetworkInstanceName).WithID(1).AddNextHop(1, 1).AddNextHop(2, 1),
+				fluent.IPv4Entry().WithPrefix("1.0.0.0/8").WithNetworkInstance(defaultNetworkInstanceName).WithNextHopGroup(1))
 		},
 	}
 
@@ -1142,7 +1153,7 @@ func DeleteIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t 
 	ops := []func(){
 		func() { baseTopologyEntries(c, t) },
 		func() {
-			c.Modify().DeleteEntry(t, fluent.IPv4Entry().WithPrefix("1.0.0.0/8").WithNetworkInstance(server.DefaultNetworkInstanceName))
+			c.Modify().DeleteEntry(t, fluent.IPv4Entry().WithPrefix("1.0.0.0/8").WithNetworkInstance(defaultNetworkInstanceName))
 		},
 	}
 	res := doModifyOps(c, t, ops, wantACK, false)
@@ -1164,7 +1175,7 @@ func DeleteReferencedNHGFailure(c *fluent.GRIBIClient, wantACK fluent.Programmin
 	ops := []func(){
 		func() { baseTopologyEntries(c, t) },
 		func() {
-			c.Modify().DeleteEntry(t, fluent.NextHopGroupEntry().WithID(1).WithNetworkInstance(server.DefaultNetworkInstanceName))
+			c.Modify().DeleteEntry(t, fluent.NextHopGroupEntry().WithID(1).WithNetworkInstance(defaultNetworkInstanceName))
 		},
 	}
 	res := doModifyOps(c, t, ops, wantACK, false)
@@ -1185,10 +1196,10 @@ func DeleteReferencedNHFailure(c *fluent.GRIBIClient, wantACK fluent.Programming
 	ops := []func(){
 		func() { baseTopologyEntries(c, t) },
 		func() {
-			c.Modify().DeleteEntry(t, fluent.NextHopEntry().WithIndex(1).WithNetworkInstance(server.DefaultNetworkInstanceName))
+			c.Modify().DeleteEntry(t, fluent.NextHopEntry().WithIndex(1).WithNetworkInstance(defaultNetworkInstanceName))
 		},
 		func() {
-			c.Modify().DeleteEntry(t, fluent.NextHopEntry().WithIndex(2).WithNetworkInstance(server.DefaultNetworkInstanceName))
+			c.Modify().DeleteEntry(t, fluent.NextHopEntry().WithIndex(2).WithNetworkInstance(defaultNetworkInstanceName))
 		},
 	}
 	res := doModifyOps(c, t, ops, wantACK, false)
@@ -1212,8 +1223,8 @@ func DeleteNextHopGroup(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult,
 		func() { baseTopologyEntries(c, t) },
 		func() {
 			c.Modify().DeleteEntry(t,
-				fluent.IPv4Entry().WithPrefix("1.0.0.0/8").WithNetworkInstance(server.DefaultNetworkInstanceName),
-				fluent.NextHopGroupEntry().WithID(1).WithNetworkInstance(server.DefaultNetworkInstanceName),
+				fluent.IPv4Entry().WithPrefix("1.0.0.0/8").WithNetworkInstance(defaultNetworkInstanceName),
+				fluent.NextHopGroupEntry().WithID(1).WithNetworkInstance(defaultNetworkInstanceName),
 			)
 		},
 	}
@@ -1245,10 +1256,10 @@ func DeleteNextHop(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t te
 		func() { baseTopologyEntries(c, t) },
 		func() {
 			c.Modify().DeleteEntry(t,
-				fluent.IPv4Entry().WithPrefix("1.0.0.0/8").WithNetworkInstance(server.DefaultNetworkInstanceName),
-				fluent.NextHopGroupEntry().WithID(1).WithNetworkInstance(server.DefaultNetworkInstanceName),
-				fluent.NextHopEntry().WithIndex(1).WithNetworkInstance(server.DefaultNetworkInstanceName),
-				fluent.NextHopEntry().WithIndex(2).WithNetworkInstance(server.DefaultNetworkInstanceName),
+				fluent.IPv4Entry().WithPrefix("1.0.0.0/8").WithNetworkInstance(defaultNetworkInstanceName),
+				fluent.NextHopGroupEntry().WithID(1).WithNetworkInstance(defaultNetworkInstanceName),
+				fluent.NextHopEntry().WithIndex(1).WithNetworkInstance(defaultNetworkInstanceName),
+				fluent.NextHopEntry().WithIndex(2).WithNetworkInstance(defaultNetworkInstanceName),
 			)
 		},
 	}
@@ -1296,16 +1307,16 @@ func AddDeleteAdd(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t tes
 			c.Modify().AddEntry(t,
 				fluent.IPv4Entry().
 					WithPrefix("2.0.0.0/8").
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithNextHopGroup(1))
 			c.Modify().DeleteEntry(t,
 				fluent.IPv4Entry().
 					WithPrefix("2.0.0.0/8").
-					WithNetworkInstance(server.DefaultNetworkInstanceName))
+					WithNetworkInstance(defaultNetworkInstanceName))
 			c.Modify().AddEntry(t,
 				fluent.IPv4Entry().
 					WithPrefix("2.0.0.0/8").
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithNextHopGroup(1))
 		},
 	}

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -939,7 +939,8 @@ func ReplaceMissingNHG(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
 					WithNetworkInstance(defaultNetworkInstanceName).
-					WithIndex(42))
+					WithIndex(42).
+					WithIPAddress("1.1.1.1"))
 
 			c.Modify().ReplaceEntry(t,
 				fluent.NextHopGroupEntry().

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -551,14 +551,14 @@ func AddIPv4EntryRandom(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 func AddIPv4Metadata(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 	ops := []func(){
 		func() {
+			c.Modify().AddEntry(t, fluent.NextHopEntry().WithIndex(1).WithNetworkInstance(defaultNetworkInstanceName).WithIPAddress("2.2.2.2"))
+			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithID(1).WithNetworkInstance(defaultNetworkInstanceName).AddNextHop(1, 1))
 			c.Modify().AddEntry(t, fluent.IPv4Entry().
 				WithPrefix("1.1.1.1/32").
 				WithNetworkInstance(defaultNetworkInstanceName).
 				WithNextHopGroup(1).
 				WithMetadata([]byte{1, 2, 3, 4, 5, 6, 7, 8}),
 			)
-			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithID(1).WithNetworkInstance(defaultNetworkInstanceName).AddNextHop(1, 1))
-			c.Modify().AddEntry(t, fluent.NextHopEntry().WithIndex(1).WithNetworkInstance(defaultNetworkInstanceName).WithIPAddress("2.2.2.2"))
 		},
 	}
 

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -311,57 +311,57 @@ var (
 	}, {
 		In: Test{
 			Fn:        TestUnsupportedElectionParams,
-			ShortName: "Ensure that election ID is not accepted in ALL_PRIMARY mode",
+			ShortName: "Election - Ensure that election ID is not accepted in ALL_PRIMARY mode",
 		},
 	}, {
 		In: Test{
 			Fn:        TestDifferingElectionParameters,
-			ShortName: "Ensure that a client with mismatched parameters is rejected",
+			ShortName: "Election - Ensure that a client with mismatched parameters is rejected",
 		},
 	}, {
 		In: Test{
 			Fn:        TestMatchingElectionParameters,
-			ShortName: "Matching parameters for two clients in election",
+			ShortName: "Election - Matching parameters for two clients in election",
 		},
 	}, {
 		In: Test{
 			Fn:        TestParamsDifferFromOtherClients,
-			ShortName: "Ensure client with differing parameters is rejected",
+			ShortName: "Election - Ensure client with differing parameters is rejected",
 		},
 	}, {
 		In: Test{
 			Fn:        TestLowerElectionID,
-			ShortName: "Lower election ID from new client",
+			ShortName: "Election - Lower election ID from new client",
 		},
 	}, {
 		In: Test{
 			Fn:        TestActiveAfterMasterChange,
-			ShortName: "Active entries after new master connects",
+			ShortName: "Election - Active entries after new master connects",
 		},
 	}, {
 		In: Test{
 			Fn:        TestNewElectionIDNoUpdateRejected,
-			ShortName: "Unannounced master operations are rejected",
+			ShortName: "Election - Unannounced master operations are rejected",
 		},
 	}, {
 		In: Test{
 			Fn:        TestIncElectionID,
-			ShortName: "Incrementing election ID is honoured, and older IDs are rejected",
+			ShortName: "Election - Incrementing election ID is honoured, and older IDs are rejected",
 		},
 	}, {
 		In: Test{
 			Fn:        TestDecElectionID,
-			ShortName: "Decrementing election ID is ignored",
+			ShortName: "Election - Decrementing election ID is ignored",
 		},
 	}, {
 		In: Test{
 			Fn:        TestSameElectionIDFromTwoClients,
-			ShortName: "Sending same election ID from two clients",
+			ShortName: "Election - Sending same election ID from two clients",
 		},
 	}, {
 		In: Test{
 			Fn:        TestElectionIDAsZero,
-			ShortName: "Sending election ID as zero",
+			ShortName: "Election - Sending election ID as zero",
 		},
 	}, {
 		In: Test{
@@ -498,6 +498,8 @@ func AddIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t tes
 			WithProgrammingResult(wantACK).
 			AsResult(),
 	)
+
+	flushServer(c, t)
 }
 
 // addIPv4Random adds an IPv4 Entry, shuffling the order of the entries, and
@@ -544,6 +546,8 @@ func AddIPv4EntryRandom(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			AsResult(),
 		chk.IgnoreOperationID(),
 	)
+
+	flushServer(c, t)
 }
 
 // AddIPv4Metadata adds an IPv4 Entry (and its dependencies) with metadata alongside the
@@ -587,6 +591,8 @@ func AddIPv4Metadata(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			WithProgrammingResult(fluent.InstalledInRIB).
 			AsResult(),
 		chk.IgnoreOperationID())
+
+	flushServer(c, t)
 }
 
 // AddIPv4EntryDifferentNINHG adds an IPv4 entry that references a next-hop-group within a
@@ -631,6 +637,8 @@ func AddIPv4EntryDifferentNINHG(c *fluent.GRIBIClient, wantACK fluent.Programmin
 			WithOperationType(constants.Add).
 			AsResult(),
 		chk.IgnoreOperationID())
+
+	flushServer(c, t)
 }
 
 // doModifyOps performs the series of operations in ops using the context
@@ -701,6 +709,8 @@ func AddUnreferencedNextHopGroup(c *fluent.GRIBIClient, wantACK fluent.Programmi
 			WithProgrammingResult(wantACK).
 			AsResult(),
 	)
+
+	flushServer(c, t)
 }
 
 // ImplicitReplaceNH performs two add operations for the same NextHop entry, validating that the
@@ -743,6 +753,7 @@ func ImplicitReplaceNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, 
 			WithProgrammingResult(wantACK).
 			AsResult())
 
+	flushServer(c, t)
 }
 
 // ImplicitReplaceNHG performs two add operations for the same NextHopGroup entry, validating that the
@@ -810,6 +821,8 @@ func ImplicitReplaceNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult,
 			WithOperationType(constants.Add).
 			WithProgrammingResult(wantACK).
 			AsResult())
+
+	flushServer(c, t)
 }
 
 // ImplicitReplaceIPv4Entry performs two add operations for the same NextHopGroup entry, validating that the
@@ -905,6 +918,7 @@ func ImplicitReplaceIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingR
 			WithOperationType(constants.Add).
 			WithProgrammingResult(wantACK).
 			AsResult())
+	flushServer(c, t)
 }
 
 // ReplaceMissingNH validates that an operation for a next-hop entry that does not exist
@@ -928,6 +942,7 @@ func ReplaceMissingNH(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			WithOperationType(constants.Replace).
 			WithProgrammingResult(fluent.ProgrammingFailed).
 			AsResult())
+	flushServer(c, t)
 }
 
 // ReplaceMissingNHG validates that an operation for a next-hop-group entry that does not exist
@@ -982,6 +997,7 @@ func ReplaceMissingNHG(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			WithOperationType(constants.Delete).
 			WithProgrammingResult(fluent.InstalledInRIB).
 			AsResult())
+	flushServer(c, t)
 }
 
 // ReplaceMissingIPv4Entry validates that an operation for an IPv4 entry that does not exist
@@ -1063,6 +1079,7 @@ func ReplaceMissingIPv4Entry(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) 
 			WithOperationType(constants.Delete).
 			WithProgrammingResult(fluent.InstalledInRIB).
 			AsResult())
+	flushServer(c, t)
 }
 
 // For the following tests, the base topology shown below is assumed.
@@ -1142,6 +1159,7 @@ func AddIPv4ToMultipleNHsSingleRequest(c *fluent.GRIBIClient, wantACK fluent.Pro
 	}
 
 	validateBaseTopologyEntries(doModifyOps(c, t, ops, wantACK, false), wantACK, t)
+	flushServer(c, t)
 }
 
 // AddIPv4ToMultipleNHsMultipleRequests creates an IPv4 entry which references a NHG containing
@@ -1179,6 +1197,7 @@ func DeleteIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t 
 			AsResult(),
 		chk.IgnoreOperationID(),
 	)
+	flushServer(c, t)
 }
 
 // DeleteReferencedNHGFailure attempts to delete a NextHopGroup entry that is referenced
@@ -1200,6 +1219,7 @@ func DeleteReferencedNHGFailure(c *fluent.GRIBIClient, wantACK fluent.Programmin
 			WithProgrammingResult(fluent.ProgrammingFailed).
 			AsResult(),
 		chk.IgnoreOperationID())
+	flushServer(c, t)
 }
 
 // DeleteReferencedNHFailure attempts to delete a NH entry that is referened from the RIB
@@ -1226,6 +1246,7 @@ func DeleteReferencedNHFailure(c *fluent.GRIBIClient, wantACK fluent.Programming
 				AsResult(),
 			chk.IgnoreOperationID())
 	}
+	flushServer(c, t)
 }
 
 // DeleteNextHopGroup attempts to delete a NHG entry that is not referenced and expects
@@ -1259,6 +1280,7 @@ func DeleteNextHopGroup(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult,
 			WithProgrammingResult(wantACK).
 			AsResult(),
 		chk.IgnoreOperationID())
+	flushServer(c, t)
 }
 
 // DeleteNextHop attempts to delete the NH entries within the base topology and expects
@@ -1304,6 +1326,7 @@ func DeleteNextHop(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t te
 			WithProgrammingResult(wantACK).
 			AsResult(),
 		chk.IgnoreOperationID())
+	flushServer(c, t)
 }
 
 // AddDeleteAdd tests that when a single ModifyRequest contains a sequence of operations,
@@ -1359,4 +1382,5 @@ func AddDeleteAdd(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t tes
 			WithProgrammingResult(wantACK).
 			AsResult(),
 		chk.IgnoreOperationID())
+	flushServer(c, t)
 }

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -463,6 +463,8 @@ func ModifyConnectionSinglePrimaryPreserve(c *fluent.GRIBIClient, t testing.TB, 
 // AddIPv4Entry adds a fully referenced IPv4Entry and checks whether the specified ACK
 // type (wantACK) is returned.
 func AddIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.1"))
@@ -498,13 +500,12 @@ func AddIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t tes
 			WithProgrammingResult(wantACK).
 			AsResult(),
 	)
-
-	flushServer(c, t)
 }
 
 // addIPv4Random adds an IPv4 Entry, shuffling the order of the entries, and
 // validating those entries are ACKed.
 func AddIPv4EntryRandom(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(1))
@@ -546,13 +547,12 @@ func AddIPv4EntryRandom(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			AsResult(),
 		chk.IgnoreOperationID(),
 	)
-
-	flushServer(c, t)
 }
 
 // AddIPv4Metadata adds an IPv4 Entry (and its dependencies) with metadata alongside the
 // entry.
 func AddIPv4Metadata(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t, fluent.NextHopEntry().WithIndex(1).WithNetworkInstance(defaultNetworkInstanceName).WithIPAddress("2.2.2.2"))
@@ -591,8 +591,6 @@ func AddIPv4Metadata(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			WithProgrammingResult(fluent.InstalledInRIB).
 			AsResult(),
 		chk.IgnoreOperationID())
-
-	flushServer(c, t)
 }
 
 // AddIPv4EntryDifferentNINHG adds an IPv4 entry that references a next-hop-group within a
@@ -600,6 +598,8 @@ func AddIPv4Metadata(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 func AddIPv4EntryDifferentNINHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
 	// TODO(robjs): Server needs to be initialised with >1 VRF.
 	t.Skip()
+
+	defer flushServer(c, t)
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t, fluent.IPv4Entry().
@@ -637,8 +637,6 @@ func AddIPv4EntryDifferentNINHG(c *fluent.GRIBIClient, wantACK fluent.Programmin
 			WithOperationType(constants.Add).
 			AsResult(),
 		chk.IgnoreOperationID())
-
-	flushServer(c, t)
 }
 
 // doModifyOps performs the series of operations in ops using the context
@@ -684,6 +682,8 @@ func doModifyOps(c *fluent.GRIBIClient, t testing.TB, ops []func(), wantACK flue
 // AddUnreferencedNextHopGroup adds a NHG that is not referenced by any other entry. An ACK is expected,
 // and is validated to be of the type specified by wantACK.
 func AddUnreferencedNextHopGroup(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.1"))
@@ -709,13 +709,12 @@ func AddUnreferencedNextHopGroup(c *fluent.GRIBIClient, wantACK fluent.Programmi
 			WithProgrammingResult(wantACK).
 			AsResult(),
 	)
-
-	flushServer(c, t)
 }
 
 // ImplicitReplaceNH performs two add operations for the same NextHop entry, validating that the
 // server handles this as an implicit replace of the entry.
 func ImplicitReplaceNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -752,13 +751,13 @@ func ImplicitReplaceNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, 
 			WithOperationType(constants.Add).
 			WithProgrammingResult(wantACK).
 			AsResult())
-
-	flushServer(c, t)
 }
 
 // ImplicitReplaceNHG performs two add operations for the same NextHopGroup entry, validating that the
 // server handles this as an implicit replace of the entry.
 func ImplicitReplaceNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -821,13 +820,13 @@ func ImplicitReplaceNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult,
 			WithOperationType(constants.Add).
 			WithProgrammingResult(wantACK).
 			AsResult())
-
-	flushServer(c, t)
 }
 
 // ImplicitReplaceIPv4Entry performs two add operations for the same NextHopGroup entry, validating that the
 // server handles this as an implicit replace of the entry.
 func ImplicitReplaceIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -918,12 +917,13 @@ func ImplicitReplaceIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingR
 			WithOperationType(constants.Add).
 			WithProgrammingResult(wantACK).
 			AsResult())
-	flushServer(c, t)
 }
 
 // ReplaceMissingNH validates that an operation for a next-hop entry that does not exist
 // on the server fails.
 func ReplaceMissingNH(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		func() {
 			c.Modify().ReplaceEntry(t,
@@ -942,12 +942,13 @@ func ReplaceMissingNH(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			WithOperationType(constants.Replace).
 			WithProgrammingResult(fluent.ProgrammingFailed).
 			AsResult())
-	flushServer(c, t)
 }
 
 // ReplaceMissingNHG validates that an operation for a next-hop-group entry that does not exist
 // on the server fails.
 func ReplaceMissingNHG(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		func() {
 			// Make sure that our replace does not get rejected because of a missing reference.
@@ -997,12 +998,13 @@ func ReplaceMissingNHG(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 			WithOperationType(constants.Delete).
 			WithProgrammingResult(fluent.InstalledInRIB).
 			AsResult())
-	flushServer(c, t)
 }
 
 // ReplaceMissingIPv4Entry validates that an operation for an IPv4 entry that does not exist
 // on the server fails.
 func ReplaceMissingIPv4Entry(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -1079,7 +1081,6 @@ func ReplaceMissingIPv4Entry(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) 
 			WithOperationType(constants.Delete).
 			WithProgrammingResult(fluent.InstalledInRIB).
 			AsResult())
-	flushServer(c, t)
 }
 
 // For the following tests, the base topology shown below is assumed.
@@ -1148,6 +1149,7 @@ func validateBaseTopologyEntries(res []*client.OpResult, wantACK fluent.Programm
 // of an IPv4Entry referencing a NHG that contains multiple NHs. It uses the wantACK parameter to determine the
 // type of acknowledgement that is expected from the server.
 func AddIPv4ToMultipleNHsSingleRequest(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -1159,7 +1161,6 @@ func AddIPv4ToMultipleNHsSingleRequest(c *fluent.GRIBIClient, wantACK fluent.Pro
 	}
 
 	validateBaseTopologyEntries(doModifyOps(c, t, ops, wantACK, false), wantACK, t)
-	flushServer(c, t)
 }
 
 // AddIPv4ToMultipleNHsMultipleRequests creates an IPv4 entry which references a NHG containing
@@ -1180,6 +1181,8 @@ func makeTestWithACK(fn func(*fluent.GRIBIClient, fluent.ProgrammingResult, test
 
 // DeleteIPv4Entry deletes an IPv4 entry from the server's RIB.
 func DeleteIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		func() { baseTopologyEntries(c, t) },
 		func() {
@@ -1197,12 +1200,12 @@ func DeleteIPv4Entry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t 
 			AsResult(),
 		chk.IgnoreOperationID(),
 	)
-	flushServer(c, t)
 }
 
 // DeleteReferencedNHGFailure attempts to delete a NextHopGroup entry that is referenced
 // from the RIB, and expects a failure.
 func DeleteReferencedNHGFailure(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
 	ops := []func(){
 		func() { baseTopologyEntries(c, t) },
 		func() {
@@ -1219,12 +1222,13 @@ func DeleteReferencedNHGFailure(c *fluent.GRIBIClient, wantACK fluent.Programmin
 			WithProgrammingResult(fluent.ProgrammingFailed).
 			AsResult(),
 		chk.IgnoreOperationID())
-	flushServer(c, t)
 }
 
 // DeleteReferencedNHFailure attempts to delete a NH entry that is referened from the RIB
 // and expects a failure.
 func DeleteReferencedNHFailure(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		func() { baseTopologyEntries(c, t) },
 		func() {
@@ -1246,12 +1250,13 @@ func DeleteReferencedNHFailure(c *fluent.GRIBIClient, wantACK fluent.Programming
 				AsResult(),
 			chk.IgnoreOperationID())
 	}
-	flushServer(c, t)
 }
 
 // DeleteNextHopGroup attempts to delete a NHG entry that is not referenced and expects
 // success. The ACK type expected is validated against wantACK.
 func DeleteNextHopGroup(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		func() { baseTopologyEntries(c, t) },
 		func() {
@@ -1280,12 +1285,12 @@ func DeleteNextHopGroup(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult,
 			WithProgrammingResult(wantACK).
 			AsResult(),
 		chk.IgnoreOperationID())
-	flushServer(c, t)
 }
 
 // DeleteNextHop attempts to delete the NH entries within the base topology and expects
 // success. The ACK type returned is validated against wantACK.
 func DeleteNextHop(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
 	ops := []func(){
 		func() { baseTopologyEntries(c, t) },
 		func() {
@@ -1326,7 +1331,6 @@ func DeleteNextHop(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t te
 			WithProgrammingResult(wantACK).
 			AsResult(),
 		chk.IgnoreOperationID())
-	flushServer(c, t)
 }
 
 // AddDeleteAdd tests that when a single ModifyRequest contains a sequence of operations,
@@ -1334,6 +1338,8 @@ func DeleteNextHop(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t te
 // transactions cannot be coaesced when writing to hardware, but in order to prevent
 // pending transactions at the client, all must be acknowledged.
 func AddDeleteAdd(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		// Build the initial forwarding entries.
 		func() { baseTopologyEntries(c, t) },
@@ -1382,5 +1388,4 @@ func AddDeleteAdd(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t tes
 			WithProgrammingResult(wantACK).
 			AsResult(),
 		chk.IgnoreOperationID())
-	flushServer(c, t)
 }

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -257,7 +257,7 @@ var (
 	}, {
 		In: Test{
 			Fn:        ReplaceMissingIPv4Entry,
-			ShortName: "Ensure failure for a IPv4 entry that does not exist",
+			ShortName: "Ensure failure for an IPv4 entry that does not exist",
 		},
 	}, {
 		In: Test{
@@ -989,11 +989,11 @@ func ReplaceMissingNHG(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 func ReplaceMissingIPv4Entry(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 	ops := []func(){
 		func() {
-
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
 					WithNetworkInstance(defaultNetworkInstanceName).
-					WithIndex(42))
+					WithIndex(42).
+					WithIPAddress("2.2.2.2"))
 
 			c.Modify().AddEntry(t,
 				fluent.NextHopGroupEntry().
@@ -1128,7 +1128,7 @@ func validateBaseTopologyEntries(res []*client.OpResult, wantACK fluent.Programm
 }
 
 // AddIPv4ToMultipleNHsSingleRequest is the internal implementation of the single request installation
-// of a IPv4Entry referencing a NHG that contains multiple NHs. It uses the wantACK parameter to determine the
+// of an IPv4Entry referencing a NHG that contains multiple NHs. It uses the wantACK parameter to determine the
 // type of acknowledgement that is expected from the server.
 func AddIPv4ToMultipleNHsSingleRequest(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
 	ops := []func(){

--- a/compliance/election.go
+++ b/compliance/election.go
@@ -23,7 +23,6 @@ import (
 	"github.com/openconfig/gribigo/chk"
 	"github.com/openconfig/gribigo/constants"
 	"github.com/openconfig/gribigo/fluent"
-	"github.com/openconfig/gribigo/server"
 	"google.golang.org/grpc/codes"
 )
 
@@ -298,20 +297,20 @@ func TestActiveAfterMasterChange(c *fluent.GRIBIClient, t testing.TB, opts ...Te
 
 	clientA.Modify().AddEntry(t,
 		fluent.NextHopEntry().
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithIndex(1).
 			WithIPAddress("192.0.2.1"))
 
 	clientA.Modify().AddEntry(t,
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithID(42).
 			AddNextHop(1, 1))
 
 	clientA.Modify().AddEntry(t,
 		fluent.IPv4Entry().
 			WithPrefix("1.1.1.1/32").
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithNextHopGroup(42))
 
 	if err := awaitTimeout(context.Background(), clientA, t, time.Minute); err != nil {
@@ -347,7 +346,7 @@ func TestActiveAfterMasterChange(c *fluent.GRIBIClient, t testing.TB, opts ...Te
 
 	chkIPv4 := func(c *fluent.GRIBIClient, t testing.TB, errDetails string) {
 		gr, err := c.Get().
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithAFT(fluent.IPv4).
 			Send()
 
@@ -359,7 +358,7 @@ func TestActiveAfterMasterChange(c *fluent.GRIBIClient, t testing.TB, opts ...Te
 
 		chk.GetResponseHasEntries(t, gr,
 			fluent.IPv4Entry().
-				WithNetworkInstance(server.DefaultNetworkInstanceName).
+				WithNetworkInstance(defaultNetworkInstanceName).
 				WithNextHopGroup(42).
 				WithPrefix("1.1.1.1/32"),
 		)
@@ -394,16 +393,16 @@ func TestNewElectionIDNoUpdateRejected(c *fluent.GRIBIClient, t testing.TB, _ ..
 	entries := []fluent.GRIBIEntry{
 		fluent.NextHopEntry().
 			WithIndex(1).
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithElectionID(electionID.Load()+1, 0),
 		fluent.NextHopGroupEntry().
 			WithID(1).
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			AddNextHop(1, 1).
 			WithElectionID(electionID.Load()+1, 0),
 		fluent.IPv4Entry().
 			WithPrefix("1.1.1.1/32").
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithElectionID(electionID.Load()+1, 0),
 	}
 
@@ -455,7 +454,7 @@ func TestIncElectionID(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 
 	c.Modify().AddEntry(t, fluent.
 		NextHopEntry().
-		WithNetworkInstance(server.DefaultNetworkInstanceName).
+		WithNetworkInstance(defaultNetworkInstanceName).
 		WithIndex(1).
 		WithIPAddress("1.1.1.1"))
 
@@ -490,7 +489,7 @@ func TestIncElectionID(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 	// check old ID is not honoured.
 	c.Modify().AddEntry(t, fluent.
 		NextHopEntry().
-		WithNetworkInstance(server.DefaultNetworkInstanceName).
+		WithNetworkInstance(defaultNetworkInstanceName).
 		WithIndex(1).
 		WithIPAddress("2.2.2.2").
 		WithElectionID(electionID.Load()-1, 0))
@@ -511,7 +510,7 @@ func TestIncElectionID(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 	// check new ID is honoured.
 	c.Modify().AddEntry(t, fluent.
 		NextHopEntry().
-		WithNetworkInstance(server.DefaultNetworkInstanceName).
+		WithNetworkInstance(defaultNetworkInstanceName).
 		WithIndex(1).
 		WithIPAddress("3.3.3.3").
 		WithElectionID(electionID.Load(), 0))
@@ -601,8 +600,8 @@ func TestSameElectionIDFromTwoClients(c *fluent.GRIBIClient, t testing.TB, opts 
 		t.Fatalf("did not expect error from server in client B, got: %v", err)
 	}
 
-	clientA.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(10).WithIPAddress("192.0.2.1"))
-	clientB.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(server.DefaultNetworkInstanceName).WithIndex(10).WithIPAddress("192.0.2.1"))
+	clientA.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(10).WithIPAddress("192.0.2.1"))
+	clientB.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(10).WithIPAddress("192.0.2.1"))
 
 	clientAErr := awaitTimeout(context.Background(), clientA, t, time.Minute)
 	if err := clientAErr; err != nil {

--- a/compliance/flush.go
+++ b/compliance/flush.go
@@ -51,6 +51,7 @@ func FlushFromMasterDefaultNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingR
 	}
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 0, t)
+	flushServer(c, t)
 }
 
 // FlushFromOverrideDefaultNI programs a chain of entries into the default NI with the
@@ -76,6 +77,7 @@ func FlushFromOverrideDefaultNI(c *fluent.GRIBIClient, wantACK fluent.Programmin
 	}
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 0, t)
+	flushServer(c, t)
 }
 
 // FlushFromNonMasterDefaultNI sends a Flush to the server using an old election ID
@@ -109,6 +111,7 @@ func FlushFromNonMasterDefaultNI(c *fluent.GRIBIClient, wantACK fluent.Programmi
 	}
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 3, t)
+	flushServer(c, t)
 }
 
 // FlushOfSpecificNI programs entries into two network-instances, the default and a named
@@ -144,6 +147,7 @@ func FlushOfSpecificNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, 
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 0, t)
 	checkNIHasNEntries(ctx, c, vrfName, 3, t)
+	flushServer(c, t)
 }
 
 // FlushOfAllNIs programs entries in two network instances - the default and a
@@ -179,12 +183,13 @@ func FlushOfAllNIs(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t te
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 0, t)
 	checkNIHasNEntries(ctx, c, vrfName, 0, t)
+	flushServer(c, t)
 }
 
 // FlushServer flushes all the state on the server, but does not validate it
-// specifically. It can be called from external tests that need to clean up
+// specifically. It can be called from tests that need to clean up
 // a server between test cases.
-func FlushServer(c *fluent.GRIBIClient, t testing.TB) {
+func flushServer(c *fluent.GRIBIClient, t testing.TB) {
 	ctx := context.Background()
 	c.Start(ctx, t)
 	defer c.Stop(t)

--- a/compliance/flush.go
+++ b/compliance/flush.go
@@ -29,6 +29,7 @@ import (
 // master's election ID. It validates that no entries remain in the default network
 // instance using the Get RPC.
 func FlushFromMasterDefaultNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
 	addFlushEntriesToNI(c, defaultNetworkInstanceName, wantACK, t)
 
 	// addFlushEntriesToNI increments the election ID so to check with the current value,
@@ -51,7 +52,6 @@ func FlushFromMasterDefaultNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingR
 	}
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 0, t)
-	flushServer(c, t)
 }
 
 // FlushFromOverrideDefaultNI programs a chain of entries into the default NI with the
@@ -59,6 +59,7 @@ func FlushFromMasterDefaultNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingR
 // the election ID should be overridden and ensures that entries are removed using the
 // Get RPC.
 func FlushFromOverrideDefaultNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
 	addFlushEntriesToNI(c, defaultNetworkInstanceName, wantACK, t)
 
 	ctx := context.Background()
@@ -77,13 +78,13 @@ func FlushFromOverrideDefaultNI(c *fluent.GRIBIClient, wantACK fluent.Programmin
 	}
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 0, t)
-	flushServer(c, t)
 }
 
 // FlushFromNonMasterDefaultNI sends a Flush to the server using an old election ID
 // and  validates that the programmed chain of entries are not removed form the
 // default NI using the Get RPC.
 func FlushFromNonMasterDefaultNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
 	addFlushEntriesToNI(c, defaultNetworkInstanceName, wantACK, t)
 
 	// addFlushEntriesToNI increments the election ID so to check with the current value,
@@ -111,7 +112,6 @@ func FlushFromNonMasterDefaultNI(c *fluent.GRIBIClient, wantACK fluent.Programmi
 	}
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 3, t)
-	flushServer(c, t)
 }
 
 // FlushOfSpecificNI programs entries into two network-instances, the default and a named
@@ -120,6 +120,7 @@ func FlushFromNonMasterDefaultNI(c *fluent.GRIBIClient, wantACK fluent.Programmi
 func FlushOfSpecificNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
 	// TODO(robjs): we need to initialise the server with >1 network instance.
 	t.Skip()
+	defer flushServer(c, t)
 
 	vrfName := "TEST-VRF"
 
@@ -147,7 +148,6 @@ func FlushOfSpecificNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, 
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 0, t)
 	checkNIHasNEntries(ctx, c, vrfName, 3, t)
-	flushServer(c, t)
 }
 
 // FlushOfAllNIs programs entries in two network instances - the default and a
@@ -156,6 +156,7 @@ func FlushOfSpecificNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, 
 func FlushOfAllNIs(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
 	// TODO(robjs): we need to initialise the server with >1 network instance.
 	t.Skip()
+	defer flushServer(c, t)
 
 	vrfName := "TEST-VRF"
 
@@ -183,7 +184,6 @@ func FlushOfAllNIs(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t te
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 0, t)
 	checkNIHasNEntries(ctx, c, vrfName, 0, t)
-	flushServer(c, t)
 }
 
 // FlushServer flushes all the state on the server, but does not validate it

--- a/compliance/get.go
+++ b/compliance/get.go
@@ -69,6 +69,7 @@ func GetNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB
 			WithNetworkInstance(defaultNetworkInstanceName).
 			WithIndex(1).
 			WithIPAddress("1.1.1.1"))
+	flushServer(c, t)
 }
 
 // GetNHG validates that an installed next-hop-group is returned via the Get RPC.
@@ -128,6 +129,7 @@ func GetNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.T
 			WithID(1).
 			AddNextHop(1, 1),
 	)
+	flushServer(c, t)
 }
 
 // GetIPv4 validates that an installed IPv4 entry is returned via the Get RPC.
@@ -203,6 +205,7 @@ func GetIPv4(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.
 			WithNextHopGroup(1).
 			WithPrefix("42.42.42.42/32"),
 	)
+	flushServer(c, t)
 }
 
 // GetIPv4Chain validates that Get for all AFTs returns the chain of IPv4Entry->NHG->NH
@@ -287,6 +290,7 @@ func GetIPv4Chain(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t tes
 			WithIndex(1).
 			WithIPAddress("1.1.1.1"),
 	)
+	flushServer(c, t)
 }
 
 // indexAsIPv4 converts a uint32 index into an IP address, using the baseSlashEight argument as the
@@ -352,6 +356,7 @@ func GetBenchmarkNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t t
 
 		latency := end.Sub(start).Nanoseconds()
 		fmt.Printf("latency for %d NHs: %d\n", i, latency)
+		flushServer(c, t)
 		c.Stop(t)
 	}
 }

--- a/compliance/get.go
+++ b/compliance/get.go
@@ -27,7 +27,6 @@ import (
 	"github.com/openconfig/gribigo/client"
 	"github.com/openconfig/gribigo/constants"
 	"github.com/openconfig/gribigo/fluent"
-	"github.com/openconfig/gribigo/server"
 )
 
 // GetNH validates that an installed next-hop is returned via the Get RPC.
@@ -36,7 +35,7 @@ func GetNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(1).
 					WithIPAddress("1.1.1.1"))
 		},
@@ -57,7 +56,7 @@ func GetNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB
 	c.Start(ctx, t)
 	defer c.Stop(t)
 	gr, err := c.Get().
-		WithNetworkInstance(server.DefaultNetworkInstanceName).
+		WithNetworkInstance(defaultNetworkInstanceName).
 		WithAFT(fluent.NextHop).
 		Send()
 
@@ -67,7 +66,7 @@ func GetNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB
 
 	chk.GetResponseHasEntries(t, gr,
 		fluent.NextHopEntry().
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithIndex(1).
 			WithIPAddress("1.1.1.1"))
 }
@@ -78,14 +77,14 @@ func GetNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.T
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(1).
 					WithIPAddress("1.1.1.1"))
 		},
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopGroupEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithID(1).
 					AddNextHop(1, 1))
 		},
@@ -115,7 +114,7 @@ func GetNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.T
 	c.Start(ctx, t)
 	defer c.Stop(t)
 	gr, err := c.Get().
-		WithNetworkInstance(server.DefaultNetworkInstanceName).
+		WithNetworkInstance(defaultNetworkInstanceName).
 		WithAFT(fluent.NextHopGroup).
 		Send()
 
@@ -125,7 +124,7 @@ func GetNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.T
 
 	chk.GetResponseHasEntries(t, gr,
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithID(1).
 			AddNextHop(1, 1),
 	)
@@ -137,21 +136,21 @@ func GetIPv4(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(1).
 					WithIPAddress("1.1.1.1"))
 		},
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopGroupEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithID(1).
 					AddNextHop(1, 1))
 		},
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.IPv4Entry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithNextHopGroup(1).
 					WithPrefix("42.42.42.42/32"))
 		},
@@ -190,7 +189,7 @@ func GetIPv4(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.
 	c.Start(ctx, t)
 	defer c.Stop(t)
 	gr, err := c.Get().
-		WithNetworkInstance(server.DefaultNetworkInstanceName).
+		WithNetworkInstance(defaultNetworkInstanceName).
 		WithAFT(fluent.IPv4).
 		Send()
 
@@ -200,7 +199,7 @@ func GetIPv4(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.
 
 	chk.GetResponseHasEntries(t, gr,
 		fluent.IPv4Entry().
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithNextHopGroup(1).
 			WithPrefix("42.42.42.42/32"),
 	)
@@ -213,21 +212,21 @@ func GetIPv4Chain(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t tes
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(1).
 					WithIPAddress("1.1.1.1"))
 		},
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopGroupEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithID(1).
 					AddNextHop(1, 1))
 		},
 		func() {
 			c.Modify().AddEntry(t,
 				fluent.IPv4Entry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithNextHopGroup(1).
 					WithPrefix("42.42.42.42/32"))
 		},
@@ -266,7 +265,7 @@ func GetIPv4Chain(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t tes
 	c.Start(ctx, t)
 	defer c.Stop(t)
 	gr, err := c.Get().
-		WithNetworkInstance(server.DefaultNetworkInstanceName).
+		WithNetworkInstance(defaultNetworkInstanceName).
 		WithAFT(fluent.AllAFTs).
 		Send()
 
@@ -276,15 +275,15 @@ func GetIPv4Chain(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t tes
 
 	chk.GetResponseHasEntries(t, gr,
 		fluent.IPv4Entry().
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithNextHopGroup(1).
 			WithPrefix("42.42.42.42/32"),
 		fluent.NextHopGroupEntry().
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithID(1).
 			AddNextHop(1, 1),
 		fluent.NextHopEntry().
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithIndex(1).
 			WithIPAddress("1.1.1.1"),
 	)
@@ -308,7 +307,7 @@ func populateNNHs(c *fluent.GRIBIClient, n int, wantACK fluent.ProgrammingResult
 		ops = append(ops, func() {
 			c.Modify().AddEntry(t,
 				fluent.NextHopEntry().
-					WithNetworkInstance(server.DefaultNetworkInstanceName).
+					WithNetworkInstance(defaultNetworkInstanceName).
 					WithIndex(uint64(j)).
 					WithIPAddress(indexAsIPv4(uint32(i), 1)))
 		})
@@ -343,7 +342,7 @@ func GetBenchmarkNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t t
 
 		start := time.Now()
 		_, err := c.Get().
-			WithNetworkInstance(server.DefaultNetworkInstanceName).
+			WithNetworkInstance(defaultNetworkInstanceName).
 			WithAFT(fluent.NextHop).
 			Send()
 		end := time.Now()

--- a/compliance/get.go
+++ b/compliance/get.go
@@ -31,6 +31,7 @@ import (
 
 // GetNH validates that an installed next-hop is returned via the Get RPC.
 func GetNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -69,11 +70,12 @@ func GetNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB
 			WithNetworkInstance(defaultNetworkInstanceName).
 			WithIndex(1).
 			WithIPAddress("1.1.1.1"))
-	flushServer(c, t)
+
 }
 
 // GetNHG validates that an installed next-hop-group is returned via the Get RPC.
 func GetNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -129,11 +131,12 @@ func GetNHG(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.T
 			WithID(1).
 			AddNextHop(1, 1),
 	)
-	flushServer(c, t)
 }
 
 // GetIPv4 validates that an installed IPv4 entry is returned via the Get RPC.
 func GetIPv4(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -205,12 +208,13 @@ func GetIPv4(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.
 			WithNextHopGroup(1).
 			WithPrefix("42.42.42.42/32"),
 	)
-	flushServer(c, t)
 }
 
 // GetIPv4Chain validates that Get for all AFTs returns the chain of IPv4Entry->NHG->NH
 // required.
 func GetIPv4Chain(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
 	ops := []func(){
 		func() {
 			c.Modify().AddEntry(t,
@@ -290,7 +294,6 @@ func GetIPv4Chain(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t tes
 			WithIndex(1).
 			WithIPAddress("1.1.1.1"),
 	)
-	flushServer(c, t)
 }
 
 // indexAsIPv4 converts a uint32 index into an IP address, using the baseSlashEight argument as the
@@ -351,6 +354,7 @@ func GetBenchmarkNH(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t t
 			Send()
 		end := time.Now()
 		if err != nil {
+			flushServer(c, t)
 			t.Fatalf("got unexpected error, %v", err)
 		}
 

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -214,7 +214,7 @@ func (g *GRIBIClient) Start(ctx context.Context, t testing.TB) {
 func (g *GRIBIClient) Stop(t testing.TB) {
 	g.c.StopSending()
 	if err := g.c.Close(); err != nil {
-		t.Fatalf("cannot disconnect from server, %v", err)
+		log.Infof("cannot disconnect from server, %v", err)
 	}
 }
 


### PR DESCRIPTION
```
  * (M) cmd/ccli/ccli_test.go
    - add CLI argument for specifying network instance name.
  * (M) compliance/compliance.go
  * (M) compliance/election.go
  * (M) compliance/get.go
    - reference local configurable value of network instance name rather
      than fake server's const value.
```