### PR TITLE
Update to gRIBI devel-v1.4.0

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1078,15 +1078,12 @@ func (c *Client) Flush(ctx context.Context, req *spb.FlushRequest) (*spb.FlushRe
 		return nil, fmt.Errorf("must specify an election behaviour for a SINGLE_PRIMARY client")
 	}
 
-	switch t := req.GetElection().(type) {
+	switch req.GetElection().(type) {
 	case *spb.FlushRequest_Id:
 		if c.state.SessParams == nil || c.state.SessParams.Redundancy != spb.SessionParameters_SINGLE_PRIMARY {
 			return nil, fmt.Errorf("invalid to specify an election ID when the client is not in SINGLE_PRIMARY mode")
 		}
 	case *spb.FlushRequest_Override:
-		if !t.Override {
-			return nil, fmt.Errorf("invalid override value set to false")
-		}
 		if c.state.SessParams == nil || c.state.SessParams.Redundancy != spb.SessionParameters_SINGLE_PRIMARY {
 			return nil, fmt.Errorf("cannot override election ID when the client is in ALL_PRIMARY mode")
 		}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1205,7 +1205,7 @@ func TestFlush(t *testing.T) {
 		}(),
 		inReq: &spb.FlushRequest{
 			Election: &spb.FlushRequest_Override{
-				Override: true,
+				Override: &spb.Empty{},
 			},
 			NetworkInstance: &spb.FlushRequest_All{
 				All: &spb.Empty{},
@@ -1278,24 +1278,6 @@ func TestFlush(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
-		desc: "override set to false",
-		inClient: func() *Client {
-			c, err := New()
-			if err != nil {
-				t.Fatalf("can't initialise client, %v", err)
-			}
-			return c
-		}(),
-		inReq: &spb.FlushRequest{
-			NetworkInstance: &spb.FlushRequest_Name{
-				Name: server.DefaultNetworkInstanceName,
-			},
-			Election: &spb.FlushRequest_Override{
-				Override: false,
-			},
-		},
-		wantErr: true,
-	}, {
 		desc: "override with non-SINGLE_PRIMARY client",
 		inClient: func() *Client {
 			c, err := New()
@@ -1309,7 +1291,7 @@ func TestFlush(t *testing.T) {
 				Name: server.DefaultNetworkInstanceName,
 			},
 			Election: &spb.FlushRequest_Override{
-				Override: true,
+				Override: &spb.Empty{},
 			},
 		},
 		wantErr: true,

--- a/compliance/election.go
+++ b/compliance/election.go
@@ -133,7 +133,7 @@ func TestDifferingElectionParameters(c *fluent.GRIBIClient, t testing.TB, opts .
 
 // TestParamsDifferFromOtherClients checks that when a client A is connected as a SINGLE_PRIMARY
 // and client B connects with ALL_PRIMARY, an PARAMS_DIFFER_FROM_OTHER_CLIENTS error is returned to client B.
-
+//
 // TODO (deepgajjar): The fake implementation does not support ALL_PRIMARY. Ignore
 // the current tests since the return error would be UNSUPPORTED_PARAMS instead of PARAMS_DIFFER_FROM_OTHER_CLIENTS.
 // Add tests once the support for ALL_PRIMARY comes in.

--- a/compliance/flush.go
+++ b/compliance/flush.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package compliance
 
 import (

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -369,7 +369,7 @@ func (g *gRIBIFlush) WithElectionID(low, high uint64) *gRIBIFlush {
 // status on the gRIBI server when calling the Flush operation.
 func (g *gRIBIFlush) WithElectionOverride() *gRIBIFlush {
 	g.pb.Election = &spb.FlushRequest_Override{
-		Override: true,
+		Override: &spb.Empty{},
 	}
 	return g
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/kentik/patricia v0.0.0-20201202224819-f9447a6e25f1
 	github.com/openconfig/gnmi v0.0.0-20210527163611-d3a3e30199da
 	github.com/openconfig/goyang v0.2.9
-	github.com/openconfig/gribi v0.1.1-0.20220124194935-f16e301cc493
+	github.com/openconfig/gribi v0.1.1-0.20220126144445-1634932f9fd8
 	github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d // indirect
 	github.com/openconfig/ygot v0.13.2
 	go.uber.org/atomic v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/openconfig/goyang v0.2.9/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+R
 github.com/openconfig/gribi v0.1.1-0.20210423184541-ce37eb4ba92f/go.mod h1:OoH46A2kV42cIXGyviYmAlGmn6cHjGduyC2+I9d/iVs=
 github.com/openconfig/gribi v0.1.1-0.20220124194935-f16e301cc493 h1:4lIwB7pMo8kJ3V/S0E8jWXTaoSBgwQoxdUHCYsbH0QA=
 github.com/openconfig/gribi v0.1.1-0.20220124194935-f16e301cc493/go.mod h1:VFqGH2ZPFIfnKTimP4/AQB4OK0eySW5muJNFxXAwP6k=
+github.com/openconfig/gribi v0.1.1-0.20220126144445-1634932f9fd8 h1:V6QU1cocKPRP1yEfxg0cleaIh95d4yRY572UwKu/W+0=
+github.com/openconfig/gribi v0.1.1-0.20220126144445-1634932f9fd8/go.mod h1:VFqGH2ZPFIfnKTimP4/AQB4OK0eySW5muJNFxXAwP6k=
 github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d h1:zrs4U92QEAadFotQyidT4U8iZDJO67pXsS4r64uAHik=
 github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d/go.mod h1:x9tAZ4EwqCQ0jI8D6S8Yhw9Z0ee7/BxWQX0k0Uib5Q8=
 github.com/openconfig/ygot v0.6.0/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQSmIhqwAs=

--- a/server/server.go
+++ b/server/server.go
@@ -1040,15 +1040,8 @@ func (s *Server) checkFlushRequest(req *spb.FlushRequest) error {
 		}
 	}
 
-	if o, ok := e.(*spb.FlushRequest_Override); ok {
-		if !o.Override {
-			// TODO(robjs): see github.com/openconfig/gribi/pull/30, if this change is made
-			// then we will not need this check here.
-			return addFlushErrDetailsOrReturn(status.Newf(codes.FailedPrecondition, "election ID was not overridden"), &spb.FlushResponseError{
-				Status: spb.FlushResponseError_NOT_PRIMARY,
-			})
-		}
-	}
+	// By default, override must have been specified as Election was non-nil.
+	// return successfully.
 	return nil
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1886,28 +1886,14 @@ func TestCheckFlushRequest(t *testing.T) {
 			},
 		},
 	}, {
-		desc: "override specified as true",
+		desc: "override specified",
 		inServer: &Server{
 			curElecID: &spb.Uint128{High: 0, Low: 3},
 		},
 		inRequest: &spb.FlushRequest{
 			Election: &spb.FlushRequest_Override{
-				Override: true,
+				Override: &spb.Empty{},
 			},
-		},
-	}, {
-		desc: "override specified as false",
-		inServer: &Server{
-			curElecID: &spb.Uint128{High: 0, Low: 3},
-		},
-		inRequest: &spb.FlushRequest{
-			Election: &spb.FlushRequest_Override{
-				Override: false,
-			},
-		},
-		wantErrCode: codes.FailedPrecondition,
-		wantErrDetails: &spb.FlushResponseError{
-			Status: spb.FlushResponseError_NOT_PRIMARY,
 		},
 	}}
 
@@ -2120,7 +2106,7 @@ func TestFlush(t *testing.T) {
 				All: &spb.Empty{},
 			},
 			Election: &spb.FlushRequest_Override{
-				Override: true,
+				Override: &spb.Empty{},
 			},
 		},
 		wantEntriesInNI: map[string]int{


### PR DESCRIPTION
```
  * (M) client/client.go
  * (M) client/client_test.go
  * (M) compliance/election.go
  * (M) compliance/flush.go
  * (M) fluent/fluent.go
  * (M) server/server.go
  * (M) server/server_test.go
    - adopt devel-v1.4.0 of gRIBI which changes the override argument
       in a flush request to be an Empty vs. a boolean.
  * (M) go.mod
  * (M) go.sum
   - update dependencies.
```

Changes required to update to latest version of gRIBI.
