### PR TITLE
Fix gRIBIgo reference implementation to match updated spec.

### DIFF
--- a/compliance/election.go
+++ b/compliance/election.go
@@ -68,6 +68,8 @@ func TestUnsupportedElectionParams(c *fluent.GRIBIClient, t testing.TB, _ ...Tes
 	)
 }
 
+// clientAB is a helper function that returns the first and optional second client
+// from a slice of TestOpts supplied to the test.
 func clientAB(c *fluent.GRIBIClient, t testing.TB, opts ...TestOpt) (*fluent.GRIBIClient, *fluent.GRIBIClient) {
 	t.Helper()
 	var clientA, clientB *fluent.GRIBIClient
@@ -572,8 +574,8 @@ func TestDecElectionID(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 }
 
 // TestSameElectionIDFromTwoClients is the test to start 2 clients with same election ID.
-// The client A should be master and client B should be non-master. The AFT operation
-// from the client B should be rejected.
+// The client A should be master initially, and be replaced with client B when it connects.
+// The AFT operation from client A should be rejected.
 func TestSameElectionIDFromTwoClients(c *fluent.GRIBIClient, t testing.TB, opts ...TestOpt) {
 	defer electionID.Inc()
 
@@ -634,14 +636,14 @@ func TestSameElectionIDFromTwoClients(c *fluent.GRIBIClient, t testing.TB, opts 
 	chk.HasResult(t, clientA.Results(t),
 		fluent.OperationResult().
 			WithOperationID(1).
-			WithProgrammingResult(fluent.InstalledInRIB).
+			WithProgrammingResult(fluent.ProgrammingFailed).
 			AsResult(),
 	)
 
 	chk.HasResult(t, clientB.Results(t),
 		fluent.OperationResult().
 			WithOperationID(1).
-			WithProgrammingResult(fluent.ProgrammingFailed).
+			WithProgrammingResult(fluent.InstalledInRIB).
 			AsResult(),
 	)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -631,8 +631,8 @@ func isNewMaster(cand, exist *spb.Uint128) (bool, bool, error) {
 		return true, false, nil
 	}
 
-  // Per comments in gribi.proto - if the two values are equal, then we accept the new
-  // candidate as the master, this allows for reconnections.
+	// Per comments in gribi.proto - if the two values are equal, then we accept the new
+	// candidate as the master, this allows for reconnections.
 	if cand.High == exist.High && cand.Low == exist.Low {
 		return true, true, nil
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -630,8 +630,11 @@ func isNewMaster(cand, exist *spb.Uint128) (bool, bool, error) {
 	if cand.Low > exist.Low {
 		return true, false, nil
 	}
+
+  // Per comments in gribi.proto - if the two values are equal, then we accept the new
+  // candidate as the master, this allows for reconnections.
 	if cand.High == exist.High && cand.Low == exist.Low {
-		return false, true, nil
+		return true, true, nil
 	}
 	// TODO(robjs): currently this is not specified in the spec, since this is the
 	// election ID going backwards, but it seems like we could not return an error here

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -493,10 +493,11 @@ func TestIsNewMaster(t *testing.T) {
 		inExist:    &spb.Uint128{High: 4, Low: 2},
 		wantMaster: true,
 	}, {
-		desc:      "equal",
-		inCand:    &spb.Uint128{High: 42, Low: 42},
-		inExist:   &spb.Uint128{High: 42, Low: 42},
-		wantEqual: true,
+		desc:       "equal",
+		inCand:     &spb.Uint128{High: 42, Low: 42},
+		inExist:    &spb.Uint128{High: 42, Low: 42},
+		wantMaster: true,
+		wantEqual:  true,
 	}, {
 		desc:       "nil input",
 		inCand:     &spb.Uint128{High: 4242, Low: 4242},


### PR DESCRIPTION
```
  * (M) compliance/election.go
   - Update test case to expect that a new client with the same election
     ID becomes the leader.
  * (M) server/server.go
  * (M) server/server_test.go
    - Update reference implementation to align with the above
      expectation.
```
