### PR TITLE
Support Docker Container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,41 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1
 
 WORKDIR /go/src/app
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:1
 WORKDIR /go/src/app
 COPY . .
 
-RUN go get -d -v ./...
-RUN go install -v ./...
+RUN go get -d -v ./... && go install -v ./...
 
-CMD ["rtr"]
+ENTRYPOINT ["/go/bin/rtr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:latest
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN go get -d -v ./...
+RUN go install -v ./...
+
+CMD ["rtr"]

--- a/cmd/rtr/main.go
+++ b/cmd/rtr/main.go
@@ -30,7 +30,7 @@ import (
 var (
 	certFile = flag.String("cert", "", "cert is the path to the server TLS certificate file")
 	keyFile  = flag.String("key", "", "key is the path to the server TLS key file")
-	gnmi     = flag.String("gnmi", ":9001", "gnmi listen address")
+	gnmi     = flag.String("gnmi", ":9339", "gnmi listen address")
 	gribi    = flag.String("gribi", ":9002", "gribi listen address")
 )
 

--- a/cmd/rtr/main.go
+++ b/cmd/rtr/main.go
@@ -17,6 +17,8 @@ package main
 import (
 	"context"
 	"flag"
+	"net"
+	"strconv"
 
 	log "github.com/golang/glog"
 	"github.com/openconfig/gribigo/device"
@@ -28,6 +30,8 @@ import (
 var (
 	certFile = flag.String("cert", "", "cert is the path to the server TLS certificate file")
 	keyFile  = flag.String("key", "", "key is the path to the server TLS key file")
+	gnmi     = flag.String("gnmi", ":9001", "gnmi listen address")
+	gribi    = flag.String("gribi", ":9002", "gribi listen address")
 )
 
 func main() {
@@ -43,7 +47,17 @@ func main() {
 	if err != nil {
 		log.Exitf("cannot initialise TLS, got: %v", err)
 	}
-	d, err := device.New(ctx, creds)
+
+	gribiHost, gribiPort, err := splitHostPort(*gribi)
+	if err != nil {
+		log.Exitf("cannot parse gribi listen address: %s", err)
+	}
+	gnmiHost, gnmiPort, err := splitHostPort(*gnmi)
+	if err != nil {
+		log.Exitf("cannot parse gnmi listen address: %s", err)
+	}
+
+	d, err := device.New(ctx, creds, device.GNMIAddr(gnmiHost, gnmiPort), device.GRIBIPort(gribiHost, gribiPort))
 	if err != nil {
 		log.Exitf("cannot start device, %v", err)
 	}
@@ -52,4 +66,18 @@ func main() {
 		log.Infof("%v", http.ListenAndServe("localhost:6060", nil))
 	}()
 	<-ctx.Done()
+}
+
+func splitHostPort(address string) (string, int, error) {
+	addr, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", 0, err
+	}
+
+	portnum, err := strconv.Atoi(port)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return addr, portnum, nil
 }


### PR DESCRIPTION
This PR adds a Docker image to be published to Github Packages.  It is triggered on each commit to the main branch.  An example of the workflow execution is [here](https://github.com/bstoll/gribigo/actions/workflows/container.yml).  The example package can be seen [here](https://github.com/bstoll/gribigo/pkgs/container/gribigo).

```
docker pull ghcr.io/bstoll/gribigo:main
...
docker run ghcr.io/bstoll/gribigo:main -h
Usage of /go/bin/rtr:
  -alsologtostderr
    	log to standard error as well as files
...
```

Additionally, args are added for gnmi and gribi ports to make the container useful in other environments (i.e. KNE).