### PR TITLE
Remove support for empty NI name per gRIBI spec.

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -617,8 +617,14 @@ func AddIPv4EntryDifferentNINHG(c *fluent.GRIBIClient, wantACK fluent.Programmin
 				WithNetworkInstance(vrfName).
 				WithNextHopGroup(1).
 				WithNextHopGroupNetworkInstance(defaultNetworkInstanceName))
-			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithID(1).AddNextHop(1, 1))
-			c.Modify().AddEntry(t, fluent.NextHopEntry().WithIndex(1).WithIPAddress("2.2.2.2"))
+			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().
+				WithNetworkInstance(defaultNetworkInstanceName).
+				WithID(1).
+				AddNextHop(1, 1))
+			c.Modify().AddEntry(t, fluent.NextHopEntry().
+				WithNetworkInstance(defaultNetworkInstanceName).
+				WithIndex(1).
+				WithIPAddress("2.2.2.2"))
 		},
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -829,28 +829,21 @@ func modifyEntry(r *rib.RIB, ni string, op *spb.AFTOperation, fibACK bool, elect
 		return nil, status.Newf(codes.Internal, "invalid nil operation received").Err()
 	}
 
-	if r == nil {
-		return nil, status.New(codes.Internal, "invalid RIB state").Err()
-	}
-
-	// Callers should have rewritten to the default network instance name, but
-	// we ensure that we are tolerant to this error by also rewriting. This helps
-	// with testing also.
-	if ni == "" {
-		ni = DefaultNetworkInstanceName
-	}
-
-	niR, ok := r.NetworkInstanceRIB(ni)
-	if !ok || !niR.IsValid() {
-		return nil, status.Newf(codes.Internal, "invalid RIB state for network instance name: '%s'", ni).Err()
-	}
-
 	res, ok, err := checkElectionForModify(op.Id, op.ElectionId, election)
 	if err != nil {
 		return nil, err
 	}
 	if !ok {
 		return res, err
+	}
+
+	if r == nil {
+		return nil, status.New(codes.Internal, "invalid RIB state").Err()
+	}
+
+	niR, ok := r.NetworkInstanceRIB(ni)
+	if !ok || !niR.IsValid() {
+		return nil, status.Newf(codes.Internal, "invalid RIB state for network instance name: '%s'", ni).Err()
 	}
 
 	results := []*spb.AFTResult{}

--- a/server/server.go
+++ b/server/server.go
@@ -759,7 +759,15 @@ func (s *Server) doModify(cid string, ops []*spb.AFTOperation, resCh chan *spb.M
 	for _, o := range ops {
 		ni := o.GetNetworkInstance()
 		if ni == "" {
-			ni = DefaultNetworkInstanceName
+			resCh <- &spb.ModifyResponse{
+				Result: []*spb.AFTResult{{
+					Id:     o.Id,
+					Status: spb.AFTResult_FAILED,
+					ErrorDetails: &spb.AFTErrorDetails{
+						ErrorMessage: `invalid network instance name "" specified`,
+					},
+				}},
+			}
 		}
 		if _, ok := s.masterRIB.NetworkInstanceRIB(ni); !ok {
 			// this is an unknown network instance, we should not return
@@ -770,6 +778,9 @@ func (s *Server) doModify(cid string, ops []*spb.AFTOperation, resCh chan *spb.M
 				Result: []*spb.AFTResult{{
 					Id:     o.Id,
 					Status: spb.AFTResult_FAILED,
+					ErrorDetails: &spb.AFTErrorDetails{
+						ErrorMessage: fmt.Sprintf(`unknown network instance "%s" specified`, ni),
+					},
 				}},
 			}
 			return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -805,7 +805,7 @@ func TestDoModify(t *testing.T) {
 		inCID: "testclient",
 		inOps: []*spb.AFTOperation{{
 			Id:              1,
-			NetworkInstance: "",
+			NetworkInstance: DefaultNetworkInstanceName,
 			Op:              spb.AFTOperation_ADD,
 			ElectionId:      &spb.Uint128{High: 42, Low: 42},
 			Entry: &spb.AFTOperation_NextHop{
@@ -862,6 +862,9 @@ func TestDoModify(t *testing.T) {
 				Result: []*spb.AFTResult{{
 					Id:     42,
 					Status: spb.AFTResult_FAILED,
+					ErrorDetails: &spb.AFTErrorDetails{
+						ErrorMessage: `unknown network instance "FISH" specified`,
+					},
 				}},
 			},
 		}},
@@ -887,7 +890,7 @@ func TestDoModify(t *testing.T) {
 		inCID: "testclient",
 		inOps: []*spb.AFTOperation{{
 			Id:              84,
-			NetworkInstance: "",
+			NetworkInstance: DefaultNetworkInstanceName,
 			Op:              spb.AFTOperation_ADD,
 			ElectionId:      &spb.Uint128{High: 42, Low: 42},
 			Entry: &spb.AFTOperation_Ipv4{
@@ -926,7 +929,7 @@ func TestDoModify(t *testing.T) {
 		inCID: "testclient",
 		inOps: []*spb.AFTOperation{{
 			Id:              1,
-			NetworkInstance: "",
+			NetworkInstance: DefaultNetworkInstanceName,
 			Op:              spb.AFTOperation_ADD,
 			ElectionId:      &spb.Uint128{High: 42, Low: 42},
 			Entry: &spb.AFTOperation_NextHop{
@@ -937,7 +940,7 @@ func TestDoModify(t *testing.T) {
 			},
 		}, {
 			Id:              2,
-			NetworkInstance: "",
+			NetworkInstance: DefaultNetworkInstanceName,
 			Op:              spb.AFTOperation_ADD,
 			ElectionId:      &spb.Uint128{High: 42, Low: 42},
 			Entry: &spb.AFTOperation_NextHop{
@@ -984,7 +987,7 @@ func TestDoModify(t *testing.T) {
 		inCID: "testclient",
 		inOps: []*spb.AFTOperation{{
 			Id:              1,
-			NetworkInstance: "",
+			NetworkInstance: DefaultNetworkInstanceName,
 			Op:              spb.AFTOperation_ADD,
 			ElectionId:      &spb.Uint128{High: 42, Low: 42},
 			Entry: &spb.AFTOperation_NextHop{
@@ -995,7 +998,7 @@ func TestDoModify(t *testing.T) {
 			},
 		}, {
 			Id:              2,
-			NetworkInstance: "",
+			NetworkInstance: DefaultNetworkInstanceName,
 			Op:              spb.AFTOperation_ADD,
 			ElectionId:      &spb.Uint128{High: 42, Low: 42},
 			Entry: &spb.AFTOperation_NextHop{
@@ -1006,7 +1009,7 @@ func TestDoModify(t *testing.T) {
 			},
 		}, {
 			Id:              3,
-			NetworkInstance: "",
+			NetworkInstance: DefaultNetworkInstanceName,
 			Op:              spb.AFTOperation_ADD,
 			ElectionId:      &spb.Uint128{High: 42, Low: 42},
 			Entry: &spb.AFTOperation_NextHopGroup{
@@ -1025,7 +1028,7 @@ func TestDoModify(t *testing.T) {
 			},
 		}, {
 			Id:              4,
-			NetworkInstance: "",
+			NetworkInstance: DefaultNetworkInstanceName,
 			Op:              spb.AFTOperation_ADD,
 			ElectionId:      &spb.Uint128{High: 42, Low: 42},
 			Entry: &spb.AFTOperation_Ipv4{


### PR DESCRIPTION
```
  * (M) compliance/compliance.go
    - Update tests that do not explicitly specify a network instance
      name for the default network instance name to include one.
  * (M) server/server.go
  * (M) server/server_test.go
    - Update reference server implementation to remove the handling
      of an empty network instance name.
```

See https://github.com/openconfig/gribi/pull/34 for details of this change.
