### PR TITLE
Ensure that AddIPv4ToMultipleNHsMultipleRequests flushes.

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -1177,6 +1177,7 @@ func AddIPv4ToMultipleNHsSingleRequest(c *fluent.GRIBIClient, wantACK fluent.Pro
 // 2 NHs within multiple ModifyReqests, validating that they are installed in the specified RIB
 // or FIB according to wantACK.
 func AddIPv4ToMultipleNHsMultipleRequests(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
 	ops := []func(){
 		func() { baseTopologyEntries(c, t) },
 	}

--- a/compliance/election.go
+++ b/compliance/election.go
@@ -41,7 +41,7 @@ func SecondClient(c *fluent.GRIBIClient) *secondClient {
 }
 
 // TestUnsupportedElectionParams ensures that election parameters that are invalid -
-// currently ALL_PRIMARY and an election ID are reported as an error.
+// currently the test covers ALL_PRIMARY and an non-nil election ID.
 func TestUnsupportedElectionParams(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 	defer electionID.Inc()
 	c.Connection().WithInitialElectionID(electionID.Load(), 0).WithRedundancyMode(fluent.AllPrimaryClients)
@@ -62,7 +62,7 @@ func TestUnsupportedElectionParams(c *fluent.GRIBIClient, t testing.TB, _ ...Tes
 		err,
 		fluent.ModifyError().
 			WithCode(codes.FailedPrecondition).
-			WithReason(fluent.ParamsDifferFromOtherClients).
+			WithReason(fluent.ElectionIDNotAllowed).
 			AsStatus(t),
 		chk.AllowUnimplemented(),
 	)


### PR DESCRIPTION
```
commit ab0bf53772ceb1ceda458233d9a6b9937eb8fefb (HEAD -> textfix, origin/textfix)
Author: Rob Shakir <robjs@google.com>
Date:   Wed Mar 9 12:08:20 2022 -0500

    Ensure that AddIPv4ToMultipleNHsMultipleRequests flushes.
    
      * (M) compliance/compliance.go
        - Add a flushServer call to AddIPv4ToMultipleNHsMultipleRequests to
          ensure that state is cleaned up.
```