### PR TITLE
fix can not receive fib from sever's response

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -759,7 +759,16 @@ func (c *Client) clearPendingOp(op *spb.AFTResult) (*OpResult, error) {
 	if v == nil {
 		return nil, fmt.Errorf("could not dequeue operation %d, unknown operation", op.Id)
 	}
-	delete(c.qs.pendq.Ops, op.Id)
+	
+	actType := c.state.SessParams.GetAckType()
+	operationStatus := op.GetStatus()
+
+	if actType == spb.SessionParameters_RIB_AND_FIB_ACK &&
+		(operationStatus == spb.AFTResult_FIB_PROGRAMMED || operationStatus == spb.AFTResult_FIB_FAILED) {
+		delete(c.qs.pendq.Ops, op.Id)
+	} else {
+		delete(c.qs.pendq.Ops, op.Id)
+	}
 
 	det := &OpDetailsResults{
 		Type: constants.OpFromAFTOp(v.Op.Op),

--- a/client/client.go
+++ b/client/client.go
@@ -760,14 +760,15 @@ func (c *Client) clearPendingOp(op *spb.AFTResult) (*OpResult, error) {
 		return nil, fmt.Errorf("could not dequeue operation %d, unknown operation", op.Id)
 	}
 	
-	actType := c.state.SessParams.GetAckType()
-	operationStatus := op.GetStatus()
-
-	if actType == spb.SessionParameters_RIB_AND_FIB_ACK &&
-		(operationStatus == spb.AFTResult_FIB_PROGRAMMED || operationStatus == spb.AFTResult_FIB_FAILED) {
-		delete(c.qs.pendq.Ops, op.Id)
-	} else {
-		delete(c.qs.pendq.Ops, op.Id)
+	switch o := op.GetStatus() {
+	  case spb.AFTResult_FIB_PROGRAMMED, spb.AFT_FIB_FAILED:
+	     delete(q, op.id)
+	  case spb.AFTResult_RIB_PROGRAMMED:
+	     if c.state.SessParams.GetAckType() != spb.SessionParameters_RIB_AND_FIB_ACK {
+		delete(q, op.id)
+	     }
+	  case spb.AFTResult_FAILED:
+	     delete(q, op.id)
 	}
 
 	det := &OpDetailsResults{

--- a/client/client.go
+++ b/client/client.go
@@ -760,15 +760,15 @@ func (c *Client) clearPendingOp(op *spb.AFTResult) (*OpResult, error) {
 		return nil, fmt.Errorf("could not dequeue operation %d, unknown operation", op.Id)
 	}
 	
-	switch o := op.GetStatus() {
-	  case spb.AFTResult_FIB_PROGRAMMED, spb.AFT_FIB_FAILED:
-	     delete(q, op.id)
-	  case spb.AFTResult_RIB_PROGRAMMED:
-	     if c.state.SessParams.GetAckType() != spb.SessionParameters_RIB_AND_FIB_ACK {
-		delete(q, op.id)
-	     }
-	  case spb.AFTResult_FAILED:
-	     delete(q, op.id)
+	switch op.GetStatus() {
+	case spb.AFTResult_FIB_PROGRAMMED, spb.AFTResult_FIB_FAILED:
+		delete(c.qs.pendq.Ops, op.Id)
+	case spb.AFTResult_RIB_PROGRAMMED:
+		if c.state.SessParams.GetAckType() != spb.SessionParameters_RIB_AND_FIB_ACK {
+			delete(c.qs.pendq.Ops, op.Id)
+		}
+	case spb.AFTResult_FAILED:
+		delete(c.qs.pendq.Ops, op.Id)
 	}
 
 	det := &OpDetailsResults{


### PR DESCRIPTION
Fix receive FIB_BACK at client side

after the change, the responses will include both FIB_BACK and RIB_BACK 

example:
<1647650625401519452 (0 nsec): AFTOperation { ID: 1, Details: <Type: Add NH Index: 1>, Status: RIB_PROGRAMMED }> 
<1647650625401519452 (0 nsec): AFTOperation { ID: 2, Details: <Type: Add NHG ID: 42>, Status: RIB_PROGRAMMED }> 
<1647650625401519452 (0 nsec): AFTOperation { ID: 3, Details: <Type: Add IPv4: 1.1.1.1/32>, Status: RIB_PROGRAMMED }> 
<1647650625401519452 (0 nsec): AFTOperation { ID: 1, Details: <Type: Add NH Index: 1>, Status: FIB_PROGRAMMED }> 
<1647650625401519452 (0 nsec): AFTOperation { ID: 2, Details: <Type: Add NHG ID: 42>, Status: FIB_PROGRAMMED }> 
<1647650625401519452 (0 nsec): AFTOperation { ID: 3, Details: <Type: Add IPv4: 1.1.1.1/32>, Status: FIB_PROGRAMMED }>]