### PR TITLE
Fix issue #118.  

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -612,19 +612,19 @@ func AddIPv4EntryDifferentNINHG(c *fluent.GRIBIClient, wantACK fluent.Programmin
 	defer flushServer(c, t)
 	ops := []func(){
 		func() {
+			c.Modify().AddEntry(t, fluent.NextHopEntry().
+				WithNetworkInstance(defaultNetworkInstanceName).
+				WithIndex(1).
+				WithIPAddress("2.2.2.2"))
+			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().
+				WithNetworkInstance(defaultNetworkInstanceName).
+				WithID(1).
+				AddNextHop(1, 1))
 			c.Modify().AddEntry(t, fluent.IPv4Entry().
 				WithPrefix("1.1.1.1/32").
 				WithNetworkInstance(vrfName).
 				WithNextHopGroup(1).
 				WithNextHopGroupNetworkInstance(defaultNetworkInstanceName))
-			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().
-				WithNetworkInstance(defaultNetworkInstanceName).
-				WithID(1).
-				AddNextHop(1, 1))
-			c.Modify().AddEntry(t, fluent.NextHopEntry().
-				WithNetworkInstance(defaultNetworkInstanceName).
-				WithIndex(1).
-				WithIPAddress("2.2.2.2"))
 		},
 	}
 


### PR DESCRIPTION
  * (M) compliance/compliance.go
    - Fixes #118
    - We expect the client keep the right ordering of the operations requests.