### PR TITLE
Unsupported AFT operation type maybe is not fatal enough to drop the connection

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -876,7 +876,7 @@ func modifyEntry(r *rib.RIB, ni string, op *spb.AFTOperation, fibACK bool, elect
 					Id:     op.GetId(),
 					Status: spb.AFTResult_FAILED,
 					ErrorDetails: &spb.AFTErrorDetails{
-						ErrorMessage: fmt.Sprintf("invalid operation type supplied, %s", op.Op),
+						ErrorMessage: fmt.Sprintf("unsupported operation type supplied, %s", op.Op),
 					},
 				},
 			},
@@ -886,7 +886,7 @@ func modifyEntry(r *rib.RIB, ni string, op *spb.AFTOperation, fibACK bool, elect
 	if ribFatalErr != nil {
 		// RIB action returned fatal error for the connection.
 		return nil, addModifyErrDetailsOrReturn(
-			status.Newf(codes.Unimplemented, "error processing operation %s, unsupported", op.Op),
+			status.Newf(codes.Unimplemented, "fatal error processing operation %s, error: %v", op.Op, ribFatalErr),
 			&spb.ModifyRPCErrorDetails{
 				Reason: spb.ModifyRPCErrorDetails_UNKNOWN,
 			},

--- a/server/server.go
+++ b/server/server.go
@@ -857,6 +857,7 @@ func modifyEntry(r *rib.RIB, ni string, op *spb.AFTOperation, fibACK bool, elect
 
 	var (
 		oks, faileds []*rib.OpResult
+		ribErr       error
 	)
 
 	switch op.Op {
@@ -865,22 +866,26 @@ func modifyEntry(r *rib.RIB, ni string, op *spb.AFTOperation, fibACK bool, elect
 		// whether the entry was an explicit replace from the op, and if so errors if the
 		// entry does not already exist.
 		log.V(2).Infof("calling AddEntry for operation ID %d", op.GetId())
-		oks, faileds, err = r.AddEntry(ni, op)
+		oks, faileds, ribErr = r.AddEntry(ni, op)
 	case spb.AFTOperation_DELETE:
-		oks, faileds, err = r.DeleteEntry(ni, op)
+		oks, faileds, ribErr = r.DeleteEntry(ni, op)
 	default:
 		return nil, status.Newf(codes.InvalidArgument, "invalid operation type supplied, %s", op.Op).Err()
 	}
-	if err != nil {
-		// this error is fatal for the connection as simply erroneous
-		// entries are just reported as failed.
-		return nil, addModifyErrDetailsOrReturn(
-			status.Newf(codes.Unimplemented, "error processing operation %s, unsupported", op.Op),
-			&spb.ModifyRPCErrorDetails{
-				Reason: spb.ModifyRPCErrorDetails_UNKNOWN,
+	if ribErr != nil {
+		return &spb.ModifyResponse{
+			Result: []*spb.AFTResult{
+				{
+					Id:     op.GetId(),
+					Status: spb.AFTResult_FAILED,
+					ErrorDetails: &spb.AFTErrorDetails{
+						ErrorMessage: fmt.Sprintf("error processing operation %s, error %v", op.Op, ribErr),
+					},
+				},
 			},
-		)
+		}, nil
 	}
+
 	for _, ok := range oks {
 		log.V(2).Infof("received OK for %d in operation %s", ok.ID, prototext.Format(op))
 		results = append(results, &spb.AFTResult{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1248,6 +1248,30 @@ func TestModifyEntry(t *testing.T) {
 		inRIB:       rib.New(defName),
 		wantErrCode: codes.Internal,
 	}, {
+		desc:  "unsupported operation type",
+		inRIB: rib.New(defName, rib.DisableRIBCheckFn()),
+		inNI:  defName,
+		inOp: &spb.AFTOperation{
+			ElectionId: &spb.Uint128{High: 0, Low: 2},
+			Id:         2,
+			Op:         spb.AFTOperation_INVALID,
+		},
+		inElection: &electionDetails{
+			master:       "this-client",
+			ID:           &spb.Uint128{High: 0, Low: 2},
+			client:       "this-client",
+			clientLatest: &spb.Uint128{High: 0, Low: 2},
+		},
+		wantResponse: &spb.ModifyResponse{
+			Result: []*spb.AFTResult{{
+				Id:     2,
+				Status: spb.AFTResult_FAILED,
+				ErrorDetails: &spb.AFTErrorDetails{
+					ErrorMessage: "unsupported operation type supplied, INVALID",
+				},
+			}},
+		},
+	}, {
 		desc:        "nil RIB",
 		wantErrCode: codes.Internal,
 	}, {


### PR DESCRIPTION
Propose to maintain the connection in the case of unsupported AFT operations. If use case demands, maybe we can later consider adding a new [AFTResult.Status](https://github.com/openconfig/gribi/blob/7d876062a31f072bd5b9159b522120ef3fdb5f44/v1/proto/service/gribi.proto#L242) for the client to action upon. 