### PR TITLE
Uses the IANA reserved port by default in the virtual router implementation

### DIFF
--- a/cmd/rtr/main.go
+++ b/cmd/rtr/main.go
@@ -31,7 +31,7 @@ var (
 	certFile = flag.String("cert", "", "cert is the path to the server TLS certificate file")
 	keyFile  = flag.String("key", "", "key is the path to the server TLS key file")
 	gnmi     = flag.String("gnmi", ":9339", "gnmi listen address")
-	gribi    = flag.String("gribi", ":9002", "gribi listen address")
+	gribi    = flag.String("gribi", ":9340", "gribi listen address")
 )
 
 func main() {

--- a/device/device.go
+++ b/device/device.go
@@ -62,6 +62,8 @@ const (
 	// TODO(robjs): support dynamic naming so tha twe can run N different
 	// fakes at the same time.
 	targetName string = "DUT"
+	// IANA reserves 9340 for gRIBI service.
+	gRIBIPort = 9340
 )
 
 // DevOpt is an interface that is implemented by options that can be handed to New()
@@ -287,6 +289,9 @@ func optTLSCreds(opts []DevOpt) *tlsCreds {
 // and the specified TLS credentials, with the specified options.
 // It returns a function to stop the server, and error if the server cannot be started.
 func (d *Device) startgRIBI(ctx context.Context, host string, port int, creds *tlsCreds, opt ...server.ServerOpt) (func(), error) {
+	if port == 0 {
+		port = gRIBIPort
+	}
 	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil, fmt.Errorf("cannot create gRPC server for gRIBI, %v", err)

--- a/device/device.go
+++ b/device/device.go
@@ -62,8 +62,6 @@ const (
 	// TODO(robjs): support dynamic naming so tha twe can run N different
 	// fakes at the same time.
 	targetName string = "DUT"
-	// IANA reserves 9340 for gRIBI service.
-	gRIBIPort = 9340
 )
 
 // DevOpt is an interface that is implemented by options that can be handed to New()
@@ -289,9 +287,6 @@ func optTLSCreds(opts []DevOpt) *tlsCreds {
 // and the specified TLS credentials, with the specified options.
 // It returns a function to stop the server, and error if the server cannot be started.
 func (d *Device) startgRIBI(ctx context.Context, host string, port int, creds *tlsCreds, opt ...server.ServerOpt) (func(), error) {
-	if port == 0 {
-		port = gRIBIPort
-	}
 	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil, fmt.Errorf("cannot create gRPC server for gRIBI, %v", err)


### PR DESCRIPTION
[IANA reserves 9340 for gRIBI](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=9340#Google_Networking)