### PR TITLE
Update server implementation per gribi proto devel-v1.5.0

### DIFF
--- a/compliance/flush.go
+++ b/compliance/flush.go
@@ -23,6 +23,8 @@ import (
 	"github.com/openconfig/gribigo/fluent"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	spb "github.com/openconfig/gribi/v1/proto/service"
 )
 
 // FlushFromMasterDefaultNI programs a chain of entries into the default NI with the
@@ -48,8 +50,8 @@ func FlushFromMasterDefaultNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingR
 	switch {
 	case err != nil:
 		t.Fatalf("got unexpected error from flush, got: %v", err)
-	case fr == nil:
-		t.Fatalf("got nil response from flush, got: %v", fr)
+	case fr.GetResult() != spb.FlushResponse_OK:
+		t.Fatalf("unexpected response from flush, got: %v, want: %v", fr.GetResult().String(), spb.FlushResponse_OK.String())
 	}
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 0, t)
@@ -74,8 +76,8 @@ func FlushFromOverrideDefaultNI(c *fluent.GRIBIClient, wantACK fluent.Programmin
 	switch {
 	case err != nil:
 		t.Fatalf("got unexpected error from flush, got: %v", err)
-	case fr == nil:
-		t.Fatalf("got nil response from flush, got: %v", fr)
+	case fr.GetResult() != spb.FlushResponse_OK:
+		t.Fatalf("unexpected response from flush, got: %v, want: %v", fr.GetResult().String(), spb.FlushResponse_OK.String())
 	}
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 0, t)
@@ -139,8 +141,8 @@ func FlushOfSpecificNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, 
 	switch {
 	case err != nil:
 		t.Fatalf("got unexpected error from flush, got: %v", err)
-	case fr == nil:
-		t.Fatalf("got nil response from flush, got: %v", fr)
+	case fr.GetResult() != spb.FlushResponse_OK:
+		t.Fatalf("unexpected response from flush, got: %v, want: %v", fr.GetResult().String(), spb.FlushResponse_OK.String())
 	}
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 0, t)
@@ -175,8 +177,8 @@ func FlushOfAllNIs(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t te
 	switch {
 	case err != nil:
 		t.Fatalf("got unexpected error from flush, got: %v", err)
-	case fr == nil:
-		t.Fatalf("got nil response from flush, got: %v", fr)
+	case fr.GetResult() != spb.FlushResponse_OK:
+		t.Fatalf("unexpected response from flush, got: %v, want: %v", fr.GetResult().String(), spb.FlushResponse_OK.String())
 	}
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 0, t)
@@ -206,8 +208,8 @@ func FlushPreservesDefaultNI(c *fluent.GRIBIClient, wantACK fluent.ProgrammingRe
 	switch {
 	case err != nil:
 		t.Fatalf("got unexpected error from flush, got: %v", err)
-	case fr == nil:
-		t.Fatalf("got nil response from flush, got: %v", fr)
+	case fr.GetResult() != spb.FlushResponse_OK:
+		t.Fatalf("unexpected response from flush, got: %v, want: %v", fr.GetResult().String(), spb.FlushResponse_OK.String())
 	}
 
 	checkNIHasNEntries(ctx, c, defaultNetworkInstanceName, 3, t)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/kentik/patricia v0.0.0-20201202224819-f9447a6e25f1
 	github.com/openconfig/gnmi v0.0.0-20210527163611-d3a3e30199da
 	github.com/openconfig/goyang v1.0.0
-	github.com/openconfig/gribi v0.1.1-0.20220126144445-1634932f9fd8
+	github.com/openconfig/gribi v0.1.1-0.20220520020624-63905fc23f56
 	github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d // indirect
 	github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07
 	github.com/openconfig/ygot v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/openconfig/goyang v0.2.9/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+R
 github.com/openconfig/goyang v1.0.0 h1:nYaFu7BOAk/eQn4CgAUjgYPfp3J6CdXrBryp32E5CjI=
 github.com/openconfig/goyang v1.0.0/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+RrNkXRd3W8=
 github.com/openconfig/gribi v0.1.1-0.20210423184541-ce37eb4ba92f/go.mod h1:OoH46A2kV42cIXGyviYmAlGmn6cHjGduyC2+I9d/iVs=
-github.com/openconfig/gribi v0.1.1-0.20220126144445-1634932f9fd8 h1:V6QU1cocKPRP1yEfxg0cleaIh95d4yRY572UwKu/W+0=
-github.com/openconfig/gribi v0.1.1-0.20220126144445-1634932f9fd8/go.mod h1:VFqGH2ZPFIfnKTimP4/AQB4OK0eySW5muJNFxXAwP6k=
+github.com/openconfig/gribi v0.1.1-0.20220520020624-63905fc23f56 h1:IndsqbKNjq5UkF4aZ7Iy25bFTJrjOXOlhm5Q3a7SkBY=
+github.com/openconfig/gribi v0.1.1-0.20220520020624-63905fc23f56/go.mod h1:VFqGH2ZPFIfnKTimP4/AQB4OK0eySW5muJNFxXAwP6k=
 github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d h1:zrs4U92QEAadFotQyidT4U8iZDJO67pXsS4r64uAHik=
 github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d/go.mod h1:x9tAZ4EwqCQ0jI8D6S8Yhw9Z0ee7/BxWQX0k0Uib5Q8=
 github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07 h1:X631iD/B0ximGFb5P9LY5wHju4SiedxUhc5UZEo7VSw=

--- a/rib/rib_test.go
+++ b/rib/rib_test.go
@@ -3358,8 +3358,10 @@ func TestFlush(t *testing.T) {
 			r := NewRIBHolder("DEFAULT")
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
-				Index:   1,
-				NextHop: &aftpb.Afts_NextHop{},
+				Index: 1,
+				NextHop: &aftpb.Afts_NextHop{
+					IpAddress: &wpb.StringValue{Value: "1.2.3.4"},
+				},
 			}, false)
 			if err != nil {
 				t.Fatalf("cannot add next-hop, %v", err)
@@ -3373,8 +3375,10 @@ func TestFlush(t *testing.T) {
 			r := NewRIBHolder("DEFAULT")
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
-				Index:   1,
-				NextHop: &aftpb.Afts_NextHop{},
+				Index: 1,
+				NextHop: &aftpb.Afts_NextHop{
+					IpAddress: &wpb.StringValue{Value: "1.2.3.4"},
+				},
 			}, false)
 			if err != nil {
 				t.Fatalf("cannot add next-hop, %v", err)
@@ -3403,8 +3407,10 @@ func TestFlush(t *testing.T) {
 			r := NewRIBHolder("DEFAULT")
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
-				Index:   1,
-				NextHop: &aftpb.Afts_NextHop{},
+				Index: 1,
+				NextHop: &aftpb.Afts_NextHop{
+					IpAddress: &wpb.StringValue{Value: "1.2.3.4"},
+				},
 			}, false)
 			if err != nil {
 				t.Fatalf("cannot add next-hop, %v", err)
@@ -3449,8 +3455,10 @@ func TestFlush(t *testing.T) {
 			r := NewRIBHolder("DEFAULT")
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
-				Index:   1,
-				NextHop: &aftpb.Afts_NextHop{},
+				Index: 1,
+				NextHop: &aftpb.Afts_NextHop{
+					IpAddress: &wpb.StringValue{Value: "1.2.3.4"},
+				},
 			}, false)
 			if err != nil {
 				t.Fatalf("cannot add next-hop, %v", err)
@@ -3496,8 +3504,10 @@ func TestFlush(t *testing.T) {
 			r := NewRIBHolder("DEFAULT")
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
-				Index:   1,
-				NextHop: &aftpb.Afts_NextHop{},
+				Index: 1,
+				NextHop: &aftpb.Afts_NextHop{
+					IpAddress: &wpb.StringValue{Value: "1.2.3.4"},
+				},
 			}, false)
 			if err != nil {
 				t.Fatalf("cannot add next-hop, %v", err)

--- a/rib/rib_test.go
+++ b/rib/rib_test.go
@@ -3358,10 +3358,8 @@ func TestFlush(t *testing.T) {
 			r := NewRIBHolder("DEFAULT")
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
-				Index: 1,
-				NextHop: &aftpb.Afts_NextHop{
-					ProgrammedIndex: &wpb.UintValue{Value: 42},
-				},
+				Index:   1,
+				NextHop: &aftpb.Afts_NextHop{},
 			}, false)
 			if err != nil {
 				t.Fatalf("cannot add next-hop, %v", err)
@@ -3375,10 +3373,8 @@ func TestFlush(t *testing.T) {
 			r := NewRIBHolder("DEFAULT")
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
-				Index: 1,
-				NextHop: &aftpb.Afts_NextHop{
-					ProgrammedIndex: &wpb.UintValue{Value: 42},
-				},
+				Index:   1,
+				NextHop: &aftpb.Afts_NextHop{},
 			}, false)
 			if err != nil {
 				t.Fatalf("cannot add next-hop, %v", err)
@@ -3387,7 +3383,6 @@ func TestFlush(t *testing.T) {
 			_, _, err = r.AddNextHopGroup(&aftpb.Afts_NextHopGroupKey{
 				Id: 1,
 				NextHopGroup: &aftpb.Afts_NextHopGroup{
-					ProgrammedId: &wpb.UintValue{Value: 1},
 					NextHop: []*aftpb.Afts_NextHopGroup_NextHopKey{{
 						Index: 1,
 						NextHop: &aftpb.Afts_NextHopGroup_NextHop{
@@ -3408,10 +3403,8 @@ func TestFlush(t *testing.T) {
 			r := NewRIBHolder("DEFAULT")
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
-				Index: 1,
-				NextHop: &aftpb.Afts_NextHop{
-					ProgrammedIndex: &wpb.UintValue{Value: 42},
-				},
+				Index:   1,
+				NextHop: &aftpb.Afts_NextHop{},
 			}, false)
 			if err != nil {
 				t.Fatalf("cannot add next-hop, %v", err)
@@ -3420,7 +3413,6 @@ func TestFlush(t *testing.T) {
 			_, _, err = r.AddNextHopGroup(&aftpb.Afts_NextHopGroupKey{
 				Id: 1,
 				NextHopGroup: &aftpb.Afts_NextHopGroup{
-					ProgrammedId: &wpb.UintValue{Value: 1},
 					NextHop: []*aftpb.Afts_NextHopGroup_NextHopKey{{
 						Index: 1,
 						NextHop: &aftpb.Afts_NextHopGroup_NextHop{
@@ -3436,7 +3428,6 @@ func TestFlush(t *testing.T) {
 			_, _, err = r.AddNextHopGroup(&aftpb.Afts_NextHopGroupKey{
 				Id: 2,
 				NextHopGroup: &aftpb.Afts_NextHopGroup{
-					ProgrammedId: &wpb.UintValue{Value: 1},
 					NextHop: []*aftpb.Afts_NextHopGroup_NextHopKey{{
 						Index: 1,
 						NextHop: &aftpb.Afts_NextHopGroup_NextHop{
@@ -3458,10 +3449,8 @@ func TestFlush(t *testing.T) {
 			r := NewRIBHolder("DEFAULT")
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
-				Index: 1,
-				NextHop: &aftpb.Afts_NextHop{
-					ProgrammedIndex: &wpb.UintValue{Value: 42},
-				},
+				Index:   1,
+				NextHop: &aftpb.Afts_NextHop{},
 			}, false)
 			if err != nil {
 				t.Fatalf("cannot add next-hop, %v", err)
@@ -3470,7 +3459,6 @@ func TestFlush(t *testing.T) {
 			_, _, err = r.AddNextHopGroup(&aftpb.Afts_NextHopGroupKey{
 				Id: 1,
 				NextHopGroup: &aftpb.Afts_NextHopGroup{
-					ProgrammedId: &wpb.UintValue{Value: 1},
 					NextHop: []*aftpb.Afts_NextHopGroup_NextHopKey{{
 						Index: 1,
 						NextHop: &aftpb.Afts_NextHopGroup_NextHop{
@@ -3487,7 +3475,6 @@ func TestFlush(t *testing.T) {
 			_, _, err = r.AddNextHopGroup(&aftpb.Afts_NextHopGroupKey{
 				Id: 2,
 				NextHopGroup: &aftpb.Afts_NextHopGroup{
-					ProgrammedId: &wpb.UintValue{Value: 1},
 					NextHop: []*aftpb.Afts_NextHopGroup_NextHopKey{{
 						Index: 1,
 						NextHop: &aftpb.Afts_NextHopGroup_NextHop{
@@ -3509,10 +3496,8 @@ func TestFlush(t *testing.T) {
 			r := NewRIBHolder("DEFAULT")
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
-				Index: 1,
-				NextHop: &aftpb.Afts_NextHop{
-					ProgrammedIndex: &wpb.UintValue{Value: 42},
-				},
+				Index:   1,
+				NextHop: &aftpb.Afts_NextHop{},
 			}, false)
 			if err != nil {
 				t.Fatalf("cannot add next-hop, %v", err)
@@ -3521,7 +3506,6 @@ func TestFlush(t *testing.T) {
 			_, _, err = r.AddNextHopGroup(&aftpb.Afts_NextHopGroupKey{
 				Id: 1,
 				NextHopGroup: &aftpb.Afts_NextHopGroup{
-					ProgrammedId: &wpb.UintValue{Value: 1},
 					NextHop: []*aftpb.Afts_NextHopGroup_NextHopKey{{
 						Index: 1,
 						NextHop: &aftpb.Afts_NextHopGroup_NextHop{

--- a/server/server.go
+++ b/server/server.go
@@ -445,6 +445,7 @@ func (s *Server) Flush(ctx context.Context, req *spb.FlushRequest) (*spb.FlushRe
 
 	return &spb.FlushResponse{
 		Timestamp: unixTS(),
+		Result:    spb.FlushResponse_OK,
 	}, nil
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2097,6 +2097,7 @@ func TestFlush(t *testing.T) {
 				All: &spb.Empty{},
 			},
 		},
+		wantResult: spb.FlushResponse_OK,
 		wantEntriesInNI: map[string]int{
 			DefaultNetworkInstanceName: 0,
 		},
@@ -2108,6 +2109,7 @@ func TestFlush(t *testing.T) {
 				Name: DefaultNetworkInstanceName,
 			},
 		},
+		wantResult: spb.FlushResponse_OK,
 		wantEntriesInNI: map[string]int{
 			DefaultNetworkInstanceName: 0,
 		},
@@ -2119,14 +2121,16 @@ func TestFlush(t *testing.T) {
 				Name: "one",
 			},
 		},
+		wantResult: spb.FlushResponse_OK,
 		wantEntriesInNI: map[string]int{
 			DefaultNetworkInstanceName: 3,
 			"one":                      0,
 		},
 	}, {
-		desc:     "don't remove any entries",
-		inServer: multiNI([]string{"two"}),
-		inReq:    &spb.FlushRequest{},
+		desc:       "don't remove any entries",
+		inServer:   multiNI([]string{"two"}),
+		inReq:      &spb.FlushRequest{},
+		wantResult: spb.FlushResponse_OK, // TODO(xw-g): The Flush() func is not checking nil request propertly. Fix it in next branch.
 		wantEntriesInNI: map[string]int{
 			DefaultNetworkInstanceName: 3,
 			"two":                      3,
@@ -2232,7 +2236,7 @@ func TestFlush(t *testing.T) {
 				return
 			}
 			if tt.wantResult != resp.GetResult() {
-				t.Fatalf("got unexpected result, got: %v, want: %v", tt.wantResult.String(), resp.Result.String())
+				t.Fatalf("got unexpected result, got: %v, want: %v", resp.Result.String(), tt.wantResult.String())
 				return
 			}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2087,6 +2087,7 @@ func TestFlush(t *testing.T) {
 		inServer        *Server
 		inReq           *spb.FlushRequest
 		wantErrCode     codes.Code
+		wantResult      spb.FlushResponse_Result
 		wantEntriesInNI map[string]int
 	}{{
 		desc:     "remove all entries in single NI as ALL",
@@ -2138,6 +2139,7 @@ func TestFlush(t *testing.T) {
 				All: &spb.Empty{},
 			},
 		},
+		wantResult: spb.FlushResponse_OK,
 		wantEntriesInNI: map[string]int{
 			DefaultNetworkInstanceName: 0,
 			"three":                    0,
@@ -2153,6 +2155,7 @@ func TestFlush(t *testing.T) {
 				Id: &spb.Uint128{High: 0, Low: 1},
 			},
 		},
+		wantResult: spb.FlushResponse_OK,
 		wantEntriesInNI: map[string]int{
 			DefaultNetworkInstanceName: 0,
 		},
@@ -2182,6 +2185,7 @@ func TestFlush(t *testing.T) {
 				Override: &spb.Empty{},
 			},
 		},
+		wantResult: spb.FlushResponse_OK,
 		wantEntriesInNI: map[string]int{
 			DefaultNetworkInstanceName: 0,
 		},
@@ -2216,7 +2220,8 @@ func TestFlush(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			if _, err := tt.inServer.Flush(context.Background(), tt.inReq); err != nil {
+			resp, err := tt.inServer.Flush(context.Background(), tt.inReq)
+			if err != nil {
 				s, ok := status.FromError(err)
 				if !ok {
 					t.Fatalf("did not get status.Status as error, got: %T %v", err, err)
@@ -2224,6 +2229,11 @@ func TestFlush(t *testing.T) {
 				if got, want := s.Code(), tt.wantErrCode; got != want {
 					t.Fatalf("did not get expected error code, got: %s, want: %s", got, want)
 				}
+				return
+			}
+			if tt.wantResult != resp.GetResult() {
+				t.Fatalf("got unexpected result, got: %v, want: %v", tt.wantResult.String(), resp.Result.String())
+				return
 			}
 
 			for ni, wantEntries := range tt.wantEntriesInNI {


### PR DESCRIPTION
* (M) go.mod
* (M) go.sum
  - Update gribi module per https://github.com/openconfig/gribi/releases/tag/devel-v1.5.0
 
* (M) server/server.go
* (M) server/server_test.go
* (M) compliance/flush.go
  - Update Flush() response per https://github.com/openconfig/gribi/pull/45
 
* (M) rib/rib_test.go
  - Update test cases per https://github.com/openconfig/gribi/pull/48

