### PR TITLE
Add MPLS Support to the `fluent` Library

### DIFF
--- a/chk/chk_test.go
+++ b/chk/chk_test.go
@@ -98,6 +98,20 @@ func TestHasMessage(t *testing.T) {
 			WithIPv4Operation("1.1.1.1/32").
 			WithOperationType(constants.Add).
 			AsResult(),
+	}, {
+		desc: "check for mpls label",
+		inResults: []*client.OpResult{{
+			OperationID: 42,
+			Details: &client.OpDetailsResults{
+				Type: constants.Add,
+				MPLSLabel: 42,
+			},
+		}},
+		inMsg: fluent.OperationResult().
+			WithOperationID(42).
+			WithMPLSOperation(42).
+			WithOperationType(constants.Add).
+			AsResult(),
 	}}
 
 	for _, tt := range tests {

--- a/chk/chk_test.go
+++ b/chk/chk_test.go
@@ -103,7 +103,7 @@ func TestHasMessage(t *testing.T) {
 		inResults: []*client.OpResult{{
 			OperationID: 42,
 			Details: &client.OpDetailsResults{
-				Type: constants.Add,
+				Type:      constants.Add,
 				MPLSLabel: 42,
 			},
 		}},

--- a/client/gribiclient.go
+++ b/client/gribiclient.go
@@ -595,6 +595,8 @@ type OpDetailsResults struct {
 	NextHopGroupID uint64
 	// IPv4Prefix is the IPv4 prefix modified by the operation.
 	IPv4Prefix string
+	// MPLSLabel is the MPLS label that was modified by the operation.
+	MPLSLabel uint64
 }
 
 // String returns a human-readable form of the OpDetailsResults
@@ -611,6 +613,8 @@ func (o *OpDetailsResults) String() string {
 		buf.WriteString(fmt.Sprintf("NHG ID: %d", o.NextHopGroupID))
 	case o.IPv4Prefix != "":
 		buf.WriteString(fmt.Sprintf("IPv4: %s", o.IPv4Prefix))
+	case o.MPLSLabel != 0:
+		buf.WriteString(fmt.Sprintf("MPLS: %d", o.MPLSLabel))
 	}
 	buf.WriteString(">")
 
@@ -808,6 +812,8 @@ func (c *Client) clearPendingOp(op *spb.AFTResult) (*OpResult, error) {
 	switch opEntry := v.Op.Entry.(type) {
 	case *spb.AFTOperation_Ipv4:
 		det.IPv4Prefix = opEntry.Ipv4.GetPrefix()
+	case *spb.AFTOperation_Mpls:
+		det.MPLSLabel = opEntry.Mpls.GetLabelUint64()
 	case *spb.AFTOperation_NextHopGroup:
 		det.NextHopGroupID = opEntry.NextHopGroup.GetId()
 	case *spb.AFTOperation_NextHop:

--- a/client/gribiclient_test.go
+++ b/client/gribiclient_test.go
@@ -1566,7 +1566,6 @@ func TestServerModifyIntegration(t *testing.T) {
 			if err := c.Connect(ctx); err != nil {
 				return fmt.Errorf("Connect(): cannot connect to server, %v", err)
 			}
-			return nil
 
 			c.Q(&spb.ModifyRequest{})
 			c.StartSending()

--- a/client/gribiclient_test.go
+++ b/client/gribiclient_test.go
@@ -1531,7 +1531,8 @@ func TestFlush(t *testing.T) {
 	}
 }
 
-// TestServerIntegration performs a basic integration test between the server and client to ensure that
+// TestServerModifyIntegration performs a basic integration test for the Modify
+// RPC between the server and client to ensure that
 // methods are covered by a test local to the client package.
 func TestServerModifyIntegration(t *testing.T) {
 	tests := []struct {
@@ -1608,7 +1609,7 @@ func TestServerModifyIntegration(t *testing.T) {
 			dctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 			defer cancel()
 			if err := c.Dial(dctx, l.Addr().String()); err != nil {
-				t.Fatalf("cannot connect to fake server, %v", err)
+				t.Fatalf("Dial(_, %s): cannot dial fake server, err: %v", l.Addr().String(), err)
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -561,7 +561,7 @@ func (i *ipv4Entry) WithElectionID(low, high uint64) *ipv4Entry {
 }
 
 // OpProto implements the gRIBIEntry interface, returning a gRIBI AFTOperation. ID
-// and ElectionID are explicitly not populated such that they can be populated by
+// is explicitly not populated such that they can be populated by
 // the function (e.g., AddEntry) to which they are an argument.
 func (i *ipv4Entry) OpProto() (*spb.AFTOperation, error) {
 	return &spb.AFTOperation{
@@ -603,6 +603,29 @@ func LabelEntry() *labelEntry {
 			LabelEntry: &aftpb.Afts_LabelEntry{},
 		},
 	}
+}
+
+// EntryProto implements the GRIBIEntry interface, to represent the label entry
+// as an AFTEntry.
+func (l *labelEntry) EntryProto() (*spb.AFTEntry, error) {
+	return &spb.AFTEntry{
+		NetworkInstance: l.ni,
+		Entry: &spb.AftEntry_Mpls{
+			Mpls: proto.Clone(l.pb).(*aftpb.Afts_LabelEntryKey),
+		},
+	}, nil
+}
+
+// OpProto implements the GRIBIEntry interface, returning a gRIBI AFTOperation. The
+// ID is explicitly not populated so it can be set by the caller.
+func (l *labelEntry) OpProto() (*spb.AFTOperation, error) {
+	return &spb.AFTOperation{
+		NetworkInstance: i.ni,
+		Entry: &spb.AFTOperation_Mpls{
+			Mpls: proto.Clone(l.pb).(*aftpb.Afts_LabelEntryKey),
+		},
+		ElectionID: i.electionID,
+	}, nil
 }
 
 // WithLabel modifies the supplied label entry to include the label that it matches.

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -377,6 +377,39 @@ func TestEntry(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		desc: "mpls entry",
+		in:   LabelEntry().WithNetworkInstance("DEFAULT").WithLabel(42).WithNextHopGroupNetworkInstance("DEFAULT").WithPoppedMPLSLabelStack(10, 20),
+		wantOpProto: &spb.AFTOperation{
+			NetworkInstance: "DEFAULT",
+			Entry: &spb.AFTOperation_Mpls{
+				Mpls: &aftpb.Afts_LabelEntryKey{
+					Label: &aftpb.Afts_LabelEntryKey_LabelUint64{LabelUint64: 42},
+					LabelEntry: &aftpb.Afts_LabelEntry{
+						NextHopGroupNetworkInstance: &wpb.StringValue{Value: "DEFAULT"},
+						PoppedMplsLabelStack: []*aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{
+							&aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{PoppedMplsLabelStackUint64: 10},
+							&aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{PoppedMplsLabelStackUint64: 20},
+						},
+					},
+				},
+			},
+		},
+		wantEntryProto: &spb.AFTEntry{
+			NetworkInstance: "DEFAULT",
+			Entry: &spb.AFTEntry_Mpls{
+				Mpls: &aftpb.Afts_LabelEntryKey{
+					Label: &aftpb.Afts_LabelEntryKey_LabelUint64{LabelUint64: 42},
+					LabelEntry: &aftpb.Afts_LabelEntry{
+						NextHopGroupNetworkInstance: &wpb.StringValue{Value: "DEFAULT"},
+						PoppedMplsLabelStack: []*aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{
+							&aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{PoppedMplsLabelStackUint64: 10},
+							&aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{PoppedMplsLabelStackUint64: 20},
+						},
+					},
+				},
+			},
+		},
 	}}
 
 	for _, tt := range tests {

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -388,8 +388,8 @@ func TestEntry(t *testing.T) {
 					LabelEntry: &aftpb.Afts_LabelEntry{
 						NextHopGroupNetworkInstance: &wpb.StringValue{Value: "DEFAULT"},
 						PoppedMplsLabelStack: []*aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{
-							&aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{PoppedMplsLabelStackUint64: 10},
-							&aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{PoppedMplsLabelStackUint64: 20},
+							{PoppedMplsLabelStackUint64: 10},
+							{PoppedMplsLabelStackUint64: 20},
 						},
 					},
 				},
@@ -403,8 +403,8 @@ func TestEntry(t *testing.T) {
 					LabelEntry: &aftpb.Afts_LabelEntry{
 						NextHopGroupNetworkInstance: &wpb.StringValue{Value: "DEFAULT"},
 						PoppedMplsLabelStack: []*aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{
-							&aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{PoppedMplsLabelStackUint64: 10},
-							&aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{PoppedMplsLabelStackUint64: 20},
+							{PoppedMplsLabelStackUint64: 10},
+							{PoppedMplsLabelStackUint64: 20},
 						},
 					},
 				},

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/kentik/patricia v0.0.0-20201202224819-f9447a6e25f1
 	github.com/openconfig/gnmi v0.0.0-20210527163611-d3a3e30199da
 	github.com/openconfig/goyang v1.0.0
-	github.com/openconfig/gribi v0.1.1-0.20220520020624-63905fc23f56
+	github.com/openconfig/gribi v0.1.1-0.20220622162620-08d53dffce45
 	github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d // indirect
 	github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07
 	github.com/openconfig/ygot v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/openconfig/goyang v1.0.0/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+R
 github.com/openconfig/gribi v0.1.1-0.20210423184541-ce37eb4ba92f/go.mod h1:OoH46A2kV42cIXGyviYmAlGmn6cHjGduyC2+I9d/iVs=
 github.com/openconfig/gribi v0.1.1-0.20220520020624-63905fc23f56 h1:IndsqbKNjq5UkF4aZ7Iy25bFTJrjOXOlhm5Q3a7SkBY=
 github.com/openconfig/gribi v0.1.1-0.20220520020624-63905fc23f56/go.mod h1:VFqGH2ZPFIfnKTimP4/AQB4OK0eySW5muJNFxXAwP6k=
+github.com/openconfig/gribi v0.1.1-0.20220622162620-08d53dffce45 h1:pmwzRJYdvc+CQDrIw6NF0XBnTng6SvMYBdZz9CeRbCk=
+github.com/openconfig/gribi v0.1.1-0.20220622162620-08d53dffce45/go.mod h1:VFqGH2ZPFIfnKTimP4/AQB4OK0eySW5muJNFxXAwP6k=
 github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d h1:zrs4U92QEAadFotQyidT4U8iZDJO67pXsS4r64uAHik=
 github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d/go.mod h1:x9tAZ4EwqCQ0jI8D6S8Yhw9Z0ee7/BxWQX0k0Uib5Q8=
 github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07 h1:X631iD/B0ximGFb5P9LY5wHju4SiedxUhc5UZEo7VSw=
@@ -97,6 +99,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20201209123823-ac852fbbde11 h1:lwlPPsmjDKK0J6eG6xDWd5XPehI0R024zxjDnw3esPA=
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1 h1:4qWs8cYYH6PoEFy4dfhDFgoMGkwAcETd+MmPdCPMzUc=
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
@@ -110,6 +113,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e h1:AyodaIpKjppX+cBfTASF2E1US3H2JFBj920Ot3rtDjs=
 golang.org/x/sys v0.0.0-20201214210602-f9fddec55a1e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44 h1:Bli41pIlzTzf3KEY06n+xnzK/BESIg2ze4Pgfh/aI8c=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -117,6 +121,7 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
this change adds support for the `label-entry` (MPLS) AFT to the `fluent` library, and client reporting.

```
 * (M) chk/chk_test.go
   - Ensure MPLS label matches are implemented correctly by chk methods.
 * (M) client/gribiclient.go
   - Add support for reporting back the MPLS label in an operation when printed.
 * (M) fluent/fluent.go
   - Add methods to next-hops to support MPLS-related fields.
   - Add new labelEntry type that allows an MPLS Label entry to be constructed.
```