### PR TITLE
Fix flakyness of TestParamsDifferFromOtherClients

### DIFF
--- a/compliance/election.go
+++ b/compliance/election.go
@@ -145,7 +145,6 @@ func TestDifferingElectionParameters(c *fluent.GRIBIClient, t testing.TB, opts .
 // Add tests once the support for ALL_PRIMARY comes in.
 func TestParamsDifferFromOtherClients(c *fluent.GRIBIClient, t testing.TB, opts ...TestOpt) {
 	defer electionID.Inc()
-
 	clientA, clientB := clientAB(c, t, opts...)
 
 	clientA.Connection().WithInitialElectionID(electionID.Load(), 0).
@@ -155,16 +154,15 @@ func TestParamsDifferFromOtherClients(c *fluent.GRIBIClient, t testing.TB, opts 
 	defer clientA.Stop(t)
 	clientA.StartSending(context.Background(), t)
 
-	clientB.Connection().WithRedundancyMode(fluent.AllPrimaryClients)
-
-	clientB.Start(context.Background(), t)
-	defer clientB.Stop(t)
-	clientB.StartSending(context.Background(), t)
-
 	clientAErr := awaitTimeout(context.Background(), clientA, t, time.Minute)
 	if err := clientAErr; err != nil {
 		t.Fatalf("did not expect error from server in client A, got: %v", err)
 	}
+
+	clientB.Connection().WithRedundancyMode(fluent.AllPrimaryClients)
+	clientB.Start(context.Background(), t)
+	defer clientB.Stop(t)
+	clientB.StartSending(context.Background(), t)
 
 	clientBErr := awaitTimeout(context.Background(), clientB, t, time.Minute)
 	if err := clientBErr; err == nil {

--- a/compliance/election.go
+++ b/compliance/election.go
@@ -145,6 +145,7 @@ func TestDifferingElectionParameters(c *fluent.GRIBIClient, t testing.TB, opts .
 // Add tests once the support for ALL_PRIMARY comes in.
 func TestParamsDifferFromOtherClients(c *fluent.GRIBIClient, t testing.TB, opts ...TestOpt) {
 	defer electionID.Inc()
+	
 	clientA, clientB := clientAB(c, t, opts...)
 
 	clientA.Connection().WithInitialElectionID(electionID.Load(), 0).

--- a/compliance/election.go
+++ b/compliance/election.go
@@ -145,7 +145,7 @@ func TestDifferingElectionParameters(c *fluent.GRIBIClient, t testing.TB, opts .
 // Add tests once the support for ALL_PRIMARY comes in.
 func TestParamsDifferFromOtherClients(c *fluent.GRIBIClient, t testing.TB, opts ...TestOpt) {
 	defer electionID.Inc()
-	
+
 	clientA, clientB := clientAB(c, t, opts...)
 
 	clientA.Connection().WithInitialElectionID(electionID.Load(), 0).


### PR DESCRIPTION
Based on the current code of TestParamsDifferFromOtherClients there is no guarantee that gribi server will receive the request from clientA before clientB. This causes the test to be flaky.  Changing the code to start the clientB after validating  clientA is already connected. 