### PR TITLE
Correct error code for FlushNIUnspecified

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1067,7 +1067,7 @@ func (s *Server) checkFlushRequest(req *spb.FlushRequest) error {
 	case req == nil:
 		return status.Newf(codes.Internal, "FlushRequest can not be nil").Err()
 	case req.GetNetworkInstance() == nil:
-		return addFlushErrDetailsOrReturn(status.Newf(codes.FailedPrecondition, "unspecified network instance"), &spb.FlushResponseError{
+		return addFlushErrDetailsOrReturn(status.Newf(codes.InvalidArgument, "unspecified network instance"), &spb.FlushResponseError{
 			Status: spb.FlushResponseError_UNSPECIFIED_NETWORK_INSTANCE,
 		})
 	case req.GetOverride() != nil:

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1895,7 +1895,7 @@ func TestCheckFlushRequest(t *testing.T) {
 				Id: &spb.Uint128{High: 0, Low: 3},
 			},
 		},
-		wantErrCode: codes.FailedPrecondition,
+		wantErrCode: codes.InvalidArgument,
 		wantErrDetails: &spb.FlushResponseError{
 			Status: spb.FlushResponseError_UNSPECIFIED_NETWORK_INSTANCE,
 		},
@@ -2146,7 +2146,7 @@ func TestFlush(t *testing.T) {
 		desc:        "error, empty request received",
 		inServer:    multiNI([]string{"two"}),
 		inReq:       &spb.FlushRequest{},
-		wantErrCode: codes.FailedPrecondition,
+		wantErrCode: codes.InvalidArgument,
 		wantEntriesInNI: map[string]int{
 			DefaultNetworkInstanceName: 3,
 			"two":                      3,
@@ -2159,7 +2159,7 @@ func TestFlush(t *testing.T) {
 				Id: &spb.Uint128{High: 0, Low: 1},
 			},
 		},
-		wantErrCode: codes.FailedPrecondition,
+		wantErrCode: codes.InvalidArgument,
 		wantEntriesInNI: map[string]int{
 			DefaultNetworkInstanceName: 3,
 		},


### PR DESCRIPTION
* Unspecified network instance should return INVALID_ARGUMENT canonical code. See https://github.com/openconfig/gribi/blob/08d53dffce45e942c6e7f07521c58b557984e4b7/v1/proto/service/gribi.proto#L527
* Add error details check in the compliant test. 