### PR TITLE
Flush() should also clear reference count

### DIFF
--- a/rib/rib_test.go
+++ b/rib/rib_test.go
@@ -3544,7 +3544,9 @@ func TestFlush(t *testing.T) {
 
 			return r
 		}(),
-	}}
+	},
+	// TODO: xw-g add a test case to test non-zero reference.
+	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -907,10 +907,9 @@ func modifyEntry(r *rib.RIB, ni string, op *spb.AFTOperation, fibACK bool, elect
 	for _, fail := range faileds {
 		log.Errorf("returning failed to client because the RIB declared it failed, %v", fail)
 		results = append(results, &spb.AFTResult{
-			Id:     fail.ID,
-			Status: spb.AFTResult_FAILED,
-			// TODO(robjs): add somewhere for the error that we provide to be
-			// returned.
+			Id:           fail.ID,
+			Status:       spb.AFTResult_FAILED,
+			ErrorDetails: &spb.AFTErrorDetails{ErrorMessage: fail.Error},
 		})
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1122,7 +1122,7 @@ func TestDoModify(t *testing.T) {
 					checkStatusErr(t, err, wantMsg.errCode, wantMsg.errReason)
 				}
 				if wantMsg.result != nil {
-					if diff := cmp.Diff(gotMsg.result, wantMsg.result, protocmp.Transform()); diff != "" {
+					if diff := cmp.Diff(gotMsg.result, wantMsg.result, protocmp.Transform(), protocmp.IgnoreFields(&spb.AFTResult{}, "error_details")); diff != "" {
 						t.Fatalf("did not get expected response, diff(-got,+want):\n%s", diff)
 					}
 				}
@@ -1603,7 +1603,7 @@ func TestModifyEntry(t *testing.T) {
 			if err != nil {
 				checkStatusErr(t, err, tt.wantErrCode, tt.wantErrDetails)
 			}
-			if diff := cmp.Diff(got, tt.wantResponse, protocmp.Transform()); diff != "" {
+			if diff := cmp.Diff(got, tt.wantResponse, protocmp.Transform(), protocmp.IgnoreFields(&spb.AFTResult{}, "error_details")); diff != "" {
 				t.Fatalf("did not get expected response, diff(-got,+want):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
* A quick fix to correct the logic that Flush() should also clear reference count.
* Update error message to help debug non zero reference case.
* Update testcase to cover the changes.