### PR TITLE
Fix unhandled NPE error in HasResultsCache.

### DIFF
--- a/chk/chk.go
+++ b/chk/chk.go
@@ -141,6 +141,11 @@ func HasResultsCache(t testing.TB, res, wants []*client.OpResult, opt ...resultO
 	}
 
 	for _, want := range wants {
+		// If we get a want that has no 'details' field, but we've been asked to check the
+		// details, then this is an error on the test author's part.
+		if want.Details == nil {
+			t.Fatalf("test error: cannot check for wanted message %v with nil details when IgnoreOperationID is specified", want)
+		}
 		switch {
 		case want.Details.NextHopGroupID != 0:
 			HasResult(t, []*client.OpResult{byNHGID[want.Details.NextHopGroupID]}, want, opt...)


### PR DESCRIPTION
```
commit 15b9914fa8271ffbb3036d4fbaa715544fad0973
Author: Rob Shakir <robjs@google.com>
Date:   Thu Sep 15 18:55:09 2022 -0700

    Add tests for large results sets.
    
     * (M) chk/chk_test.go
      - Add a check that HasResultsCache handles large sets of 'got' and 'want'
        messages.

commit 00d05df1d84d2ebc77e366c4be3bf7f7adc383af
Author: Rob Shakir <robjs@google.com>
Date:   Thu Sep 15 18:50:28 2022 -0700

    Fix NPE in HasResultsCache.
    
     * (M) chk/chk(_test)?.go
      - Add test to ensure that high-scale (4M entries) runs successfully.
      - Fix NPE that could be experienced when the results that were 'wants'
        contained a nil Details field.
```

An NPE could exist when `Details` in a wanted result was nil. Handled here. This PR also adds tests for higher-scale to ensure that HasResultsCache operates as we expect.
