### PR TITLE
Support idempotent DELETE operations

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -271,6 +271,27 @@ var (
 		},
 	}, {
 		In: Test{
+			Fn:                      makeTestWithACK(ImplicitReplaceNH, fluent.InstalledInFIB),
+			ShortName:               "Implicit replace NH entry - FIB ACK",
+			RequiresImplicitReplace: true,
+			RequiresFIBACK:          true,
+		},
+	}, {
+		In: Test{
+			Fn:                      makeTestWithACK(ImplicitReplaceNHG, fluent.InstalledInFIB),
+			ShortName:               "Implicit replace NHG entry - FIB ACK",
+			RequiresImplicitReplace: true,
+			RequiresFIBACK:          true,
+		},
+	}, {
+		In: Test{
+			Fn:                      makeTestWithACK(ImplicitReplaceIPv4Entry, fluent.InstalledInFIB),
+			ShortName:               "Implicit replace IPv4 entry - FIB ACK",
+			RequiresImplicitReplace: true,
+			RequiresFIBACK:          true,
+		},
+	}, {
+		In: Test{
 			Fn:                       makeTestWithACK(IdempotentDeleteNH, fluent.InstalledInRIB),
 			ShortName:                "Idempotent Delete NH entry - RIB ACK",
 			RequiresIdempotentDelete: true,

--- a/rib/rib.go
+++ b/rib/rib.go
@@ -1052,10 +1052,6 @@ func (r *RIBHolder) DeleteIPv4(e *aftpb.Afts_Ipv4EntryKey) (bool, *aft.Afts_Ipv4
 	}
 
 	de := r.retrieveIPv4(e.GetPrefix())
-	if de == nil {
-		// Return a failure for this operation, but there was no error.
-		return false, nil, nil
-	}
 
 	rr := &aft.RIB{}
 	rr.GetOrCreateAfts().GetOrCreateIpv4Entry(e.GetPrefix())
@@ -1122,10 +1118,6 @@ func (r *RIBHolder) DeleteNextHopGroup(e *aftpb.Afts_NextHopGroupKey) (bool, *af
 	}
 
 	de := r.retrieveNHG(e.GetId())
-	if de == nil {
-		// Return failed for this case, sicne there was no such NHG.
-		return false, nil, fmt.Errorf("cannot delete NHG ID %d since it does not exist", e.GetId())
-	}
 
 	rr := &aft.RIB{}
 	rr.GetOrCreateAfts().GetOrCreateNextHopGroup(e.GetId())
@@ -1192,10 +1184,6 @@ func (r *RIBHolder) DeleteNextHop(e *aftpb.Afts_NextHopKey) (bool, *aft.Afts_Nex
 	}
 
 	de := r.retrieveNH(e.GetIndex())
-	if de == nil {
-		// we mark that this operation failed, because there was no such entry.
-		return false, nil, fmt.Errorf("cannot delete NH Index %d since it does not exist", e.GetIndex())
-	}
 
 	rr := &aft.RIB{}
 	rr.GetOrCreateAfts().GetOrCreateNextHop(e.GetIndex())

--- a/rib/rib_test.go
+++ b/rib/rib_test.go
@@ -598,7 +598,8 @@ func TestIndividualDeleteEntryFunctions(t *testing.T) {
 		inEntry: &aftpb.Afts_Ipv4EntryKey{
 			Prefix: "1.1.1.1/32",
 		},
-		wantOK: false,
+		wantOrig: (*aft.Afts_Ipv4Entry)(nil),
+		wantOK:   true,
 	}, {
 		desc: "delete nhg",
 		inRIB: &RIBHolder{
@@ -654,16 +655,16 @@ func TestIndividualDeleteEntryFunctions(t *testing.T) {
 		inEntry: &aftpb.Afts_NextHopGroupKey{
 			Id: 1,
 		},
-		wantOK:  false,
-		wantErr: true,
+		wantOrig: (*aft.Afts_NextHopGroup)(nil),
+		wantOK:   true,
 	}, {
 		desc:  "delete nh entry, no such entry",
 		inRIB: NewRIBHolder("foo"),
 		inEntry: &aftpb.Afts_NextHopKey{
 			Index: 42,
 		},
-		wantOK:  false,
-		wantErr: true,
+		wantOrig: (*aft.Afts_NextHop)(nil),
+		wantOK:   true,
 	}}
 
 	for _, tt := range tests {
@@ -2094,7 +2095,7 @@ func TestDeleteEntry(t *testing.T) {
 				},
 			},
 		},
-		wantFails: []*OpResult{{
+		wantOKs: []*OpResult{{
 			ID: 42,
 			Op: &spb.AFTOperation{
 				Id: 42,
@@ -2105,7 +2106,6 @@ func TestDeleteEntry(t *testing.T) {
 					},
 				},
 			},
-			Error: "cannot delete NH Index 42 since it does not exist",
 		}},
 	}, {
 		desc: "delete IPv4",
@@ -2282,7 +2282,7 @@ func TestDeleteEntry(t *testing.T) {
 				},
 			},
 		},
-		wantFails: []*OpResult{{
+		wantOKs: []*OpResult{{
 			ID: 42,
 			Op: &spb.AFTOperation{
 				Id: 42,
@@ -2292,7 +2292,6 @@ func TestDeleteEntry(t *testing.T) {
 					},
 				},
 			},
-			Error: "cannot delete NHG ID 512 since it does not exist",
 		}},
 	}, {
 		desc:              "reference check after one referring entry removed - default NI",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1487,7 +1487,7 @@ func TestModifyEntry(t *testing.T) {
 		wantResponse: &spb.ModifyResponse{
 			Result: []*spb.AFTResult{{
 				Id:     2,
-				Status: spb.AFTResult_FAILED,
+				Status: spb.AFTResult_RIB_PROGRAMMED,
 			}},
 		},
 	}, {


### PR DESCRIPTION
This PR adds support for idempotent DELETE operations as described in openconfig/gribi#68.

This change effectively causes DELETE operations to (almost) always return success, even if the entry did not exist in the RIB/FIB beforehand.

Additionally, extra test cases are added for verifying implicit replace (ADD) with FIBACK responses.