### PR TITLE
Add support for MPLS label entries to RIB.

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -106,8 +106,8 @@ type Test struct {
 	// RequiresNonDefaultNINHG marks a test that configures NH and NHG entries (not
 	// including IPv4) in non-default network-instance.
 	RequiresNonDefaultNINHG bool
-  // RequiresMPLS marks a test that requires MPLS support in the gRIBI server.
-  RequiresMPLS bool
+	// RequiresMPLS marks a test that requires MPLS support in the gRIBI server.
+	RequiresMPLS bool
 }
 
 // TestSpec is a description of a test.
@@ -467,12 +467,12 @@ var (
 			ShortName:               "Flush non-default network instances preserves the default",
 			RequiresNonDefaultNINHG: false, // No entries in the non-default VRF.
 		},
-  }, {
-    In: Test{
-      Fn: makeTestWithACK(AddMPLSEntry, fluent.InstalledInRIB),
-      ShortName: "MPLS simple programming entry",
-      RequiresMPLS: true,
-    },
+	}, {
+		In: Test{
+			Fn:           makeTestWithACK(AddMPLSEntry, fluent.InstalledInRIB),
+			ShortName:    "MPLS simple programming entry",
+			RequiresMPLS: true,
+		},
 	}}
 )
 

--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -106,6 +106,8 @@ type Test struct {
 	// RequiresNonDefaultNINHG marks a test that configures NH and NHG entries (not
 	// including IPv4) in non-default network-instance.
 	RequiresNonDefaultNINHG bool
+  // RequiresMPLS marks a test that requires MPLS support in the gRIBI server.
+  RequiresMPLS bool
 }
 
 // TestSpec is a description of a test.
@@ -465,6 +467,12 @@ var (
 			ShortName:               "Flush non-default network instances preserves the default",
 			RequiresNonDefaultNINHG: false, // No entries in the non-default VRF.
 		},
+  }, {
+    In: Test{
+      Fn: makeTestWithACK(AddMPLSEntry, fluent.InstalledInRIB),
+      ShortName: "MPLS simple programming entry",
+      RequiresMPLS: true,
+    },
 	}}
 )
 

--- a/compliance/mpls.go
+++ b/compliance/mpls.go
@@ -12,10 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package compliance encapsulates a set of compliance tests for gRIBI. It is a test only
-// library. All tests are of the form func(c *fluent.GRIBIClient, t testing.TB) where the
-// client is the one that should be used for the test. The testing.TB object is used to report
-// errors.
 package compliance
 
 import (
@@ -26,6 +22,9 @@ import (
 	"github.com/openconfig/gribigo/fluent"
 )
 
+// AddMPLSEntry validates that the gRIBI server supports adding MPLS entries to
+// the set of AFT entries supported. It expects the wantACK acknowledgement
+// type.
 func AddMPLSEntry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
 	defer flushServer(c, t)
 

--- a/compliance/mpls.go
+++ b/compliance/mpls.go
@@ -1,0 +1,72 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package compliance encapsulates a set of compliance tests for gRIBI. It is a test only
+// library. All tests are of the form func(c *fluent.GRIBIClient, t testing.TB) where the
+// client is the one that should be used for the test. The testing.TB object is used to report
+// errors.
+package compliance
+
+import (
+	"testing"
+
+	"github.com/openconfig/gribigo/chk"
+	"github.com/openconfig/gribigo/constants"
+	"github.com/openconfig/gribigo/fluent"
+)
+
+func AddMPLSEntry(c *fluent.GRIBIClient, wantACK fluent.ProgrammingResult, t testing.TB, _ ...TestOpt) {
+	defer flushServer(c, t)
+
+	ops := []func(){
+		func() {
+			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.1"))
+		},
+		func() {
+			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithNetworkInstance(defaultNetworkInstanceName).WithID(1).AddNextHop(1, 1))
+		},
+		func() {
+			c.Modify().AddEntry(t, fluent.LabelEntry().WithLabel(100).WithNetworkInstance(defaultNetworkInstanceName).WithNextHopGroup(1))
+		},
+	}
+
+	res := DoModifyOps(c, t, ops, wantACK, false)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithMPLSOperation(100).
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopOperation(1).
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+
+	chk.HasResult(t, res,
+		fluent.OperationResult().
+			WithNextHopGroupOperation(1).
+			WithOperationType(constants.Add).
+			WithProgrammingResult(wantACK).
+			AsResult(),
+		chk.IgnoreOperationID(),
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/kentik/patricia v1.2.0
 	github.com/openconfig/gnmi v0.0.0-20210527163611-d3a3e30199da
 	github.com/openconfig/goyang v1.0.0
-	github.com/openconfig/gribi v0.1.1-0.20220622162620-08d53dffce45
+	github.com/openconfig/gribi v0.1.1-0.20221123184705-eba8d2fe3e12
 	github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d // indirect
 	github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07
 	github.com/openconfig/ygot v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/openconfig/goyang v1.0.0/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+R
 github.com/openconfig/gribi v0.1.1-0.20210423184541-ce37eb4ba92f/go.mod h1:OoH46A2kV42cIXGyviYmAlGmn6cHjGduyC2+I9d/iVs=
 github.com/openconfig/gribi v0.1.1-0.20220622162620-08d53dffce45 h1:pmwzRJYdvc+CQDrIw6NF0XBnTng6SvMYBdZz9CeRbCk=
 github.com/openconfig/gribi v0.1.1-0.20220622162620-08d53dffce45/go.mod h1:VFqGH2ZPFIfnKTimP4/AQB4OK0eySW5muJNFxXAwP6k=
+github.com/openconfig/gribi v0.1.1-0.20221123184705-eba8d2fe3e12 h1:Bq47s7Mcr2KYFpd4NNC0iiUAW4QujjCgtcBk8jvC9+U=
+github.com/openconfig/gribi v0.1.1-0.20221123184705-eba8d2fe3e12/go.mod h1:VFqGH2ZPFIfnKTimP4/AQB4OK0eySW5muJNFxXAwP6k=
 github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d h1:zrs4U92QEAadFotQyidT4U8iZDJO67pXsS4r64uAHik=
 github.com/openconfig/grpctunnel v0.0.0-20210610163803-fde4a9dc048d/go.mod h1:x9tAZ4EwqCQ0jI8D6S8Yhw9Z0ee7/BxWQX0k0Uib5Q8=
 github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07 h1:X631iD/B0ximGFb5P9LY5wHju4SiedxUhc5UZEo7VSw=

--- a/rib/rib.go
+++ b/rib/rib.go
@@ -1123,7 +1123,7 @@ func (r *RIBHolder) AddMPLS(e *aftpb.Afts_LabelEntryKey, explicitReplace bool) (
 	}
 
 	if e == nil {
-		return false, false, errors.New("nil IPv4 Entry provided")
+		return false, false, errors.New("nil MPLS Entry provided")
 	}
 
 	// This is a hack, since ygot does not know that the field that we

--- a/rib/rib.go
+++ b/rib/rib.go
@@ -1188,7 +1188,7 @@ func (r *RIBHolder) mplsExists(label uint32) bool {
 	return ok
 }
 
-// doAddMPLS implements the addition of the label entry speciifed by label
+// doAddMPLS implements the addition of the label entry specified by label
 // with the contents of the newRIB specified. It holds the shortest possible
 // lock on the RIB. doMPLS returns a bool indicating whether the update was
 // an implicit replace.


### PR DESCRIPTION
```
  * (M) compliance/compliance.go
    - Add initial MPLS test case to compliance suite.
  * (A) compliance/mpls.go
    -  Add a specific file for MPLS compliance suites.
  * (M) go.mod
  * (M) go.sum
    - Update to depend on development version of gribi proto pending PR
      submission.
  * (M) rib/rib.go
  * (M) rib/rib_test.go
    - Add support for adding MPLS label entries to AFTs.
```
