### PR TITLE
Add support for deleting MPLS LabelEntries.

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -473,6 +473,12 @@ var (
 			ShortName:    "MPLS simple programming entry",
 			RequiresMPLS: true,
 		},
+	}, {
+		In: Test{
+			Fn:           makeTestWithACK(DeleteMPLSEntry, fluent.InstalledInRIB),
+			ShortName:    "MPLS delete entry",
+			RequiresMPLS: true,
+		},
 	}}
 )
 

--- a/device/device.go
+++ b/device/device.go
@@ -388,6 +388,24 @@ func gnmiNoti(t constants.OpType, ts int64, ni string, e ygot.ValidatedGoStruct)
 			UsePathElem:    true,
 			PathElemPrefix: pfx,
 		})
+	case *aft.Afts_LabelEntry:
+		pfx := []*gpb.PathElem{{
+			Name: "network-instances",
+		}, {
+			Name: "network-instance",
+			Key:  map[string]string{"name": ni},
+		}, {
+			Name: "afts",
+		}, {
+			Name: "mpls",
+		}, {
+			Name: "label-entry",
+			Key:  map[string]string{"label": fmt.Sprintf("%d", t.GetLabel())},
+		}}
+		ns, err = ygot.TogNMINotifications(e, ts, ygot.GNMINotificationsConfig{
+			UsePathElem:    true,
+			PathElemPrefix: pfx,
+		})
 	}
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate notifications, %v", err)

--- a/rib/rib.go
+++ b/rib/rib.go
@@ -1264,6 +1264,10 @@ func (r *RIBHolder) DeleteLabelEntry(e *aftpb.Afts_LabelEntryKey) (bool, *aft.Af
 		return false, nil, errors.New("invalid RIB structure, nil")
 	}
 
+	if _, ok := e.GetLabel().(*aftpb.Afts_LabelEntryKey_LabelUint64); !ok {
+		return false, nil, fmt.Errorf("unsupported label type %T, only uint64 labels are supported, %v", e, e)
+	}
+
 	lbl := uint32(e.GetLabelUint64())
 
 	de := r.retrieveMPLS(lbl)

--- a/rib/rib_test.go
+++ b/rib/rib_test.go
@@ -2292,6 +2292,53 @@ func TestDeleteEntry(t *testing.T) {
 			},
 		}},
 	}, {
+		desc: "nil MPLS input",
+		inRIB: func() *RIB {
+			r := New(defName, DisableRIBCheckFn())
+			return r
+		}(),
+		inNetworkInstance: defName,
+		wantErr:           true,
+	}, {
+		desc: "delete MPLS",
+		inRIB: func() *RIB {
+			r := New(defName, DisableRIBCheckFn())
+			if _, _, err := r.AddEntry(defName, &spb.AFTOperation{
+				Id: 42,
+				Entry: &spb.AFTOperation_Mpls{
+					Mpls: &aftpb.Afts_LabelEntryKey{
+						Label:      &aftpb.Afts_LabelEntryKey_LabelUint64{LabelUint64: 42},
+						LabelEntry: &aftpb.Afts_LabelEntry{},
+					},
+				},
+			}); err != nil {
+				t.Fatalf("cannot set up test case, %v", err)
+			}
+			return r
+		}(),
+		inNetworkInstance: defName,
+		inOp: &spb.AFTOperation{
+			Id: 42,
+			Entry: &spb.AFTOperation_Mpls{
+				Mpls: &aftpb.Afts_LabelEntryKey{
+					Label:      &aftpb.Afts_LabelEntryKey_LabelUint64{LabelUint64: 42},
+					LabelEntry: &aftpb.Afts_LabelEntry{},
+				},
+			},
+		},
+		wantOKs: []*OpResult{{
+			ID: 42,
+			Op: &spb.AFTOperation{
+				Id: 42,
+				Entry: &spb.AFTOperation_Mpls{
+					Mpls: &aftpb.Afts_LabelEntryKey{
+						Label:      &aftpb.Afts_LabelEntryKey_LabelUint64{LabelUint64: 42},
+						LabelEntry: &aftpb.Afts_LabelEntry{},
+					},
+				},
+			},
+		}},
+	}, {
 		desc: "delete NHG",
 		inRIB: func() *RIB {
 			r := New(defName)

--- a/rib/rib_test.go
+++ b/rib/rib_test.go
@@ -36,6 +36,7 @@ import (
 
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	aftpb "github.com/openconfig/gribi/v1/proto/gribi_aft"
+	"github.com/openconfig/gribi/v1/proto/gribi_aft/enums"
 	spb "github.com/openconfig/gribi/v1/proto/service"
 	wpb "github.com/openconfig/ygot/proto/ywrapper"
 )
@@ -2299,6 +2300,37 @@ func TestDeleteEntry(t *testing.T) {
 		}(),
 		inNetworkInstance: defName,
 		wantErr:           true,
+	}, {
+		desc: "unsupported MPLS input",
+		inRIB: func() *RIB {
+			r := New(defName, DisableRIBCheckFn())
+			return r
+		}(),
+		inNetworkInstance: defName,
+		inOp: &spb.AFTOperation{
+			Id: 42,
+			Entry: &spb.AFTOperation_Mpls{
+				Mpls: &aftpb.Afts_LabelEntryKey{
+					Label: &aftpb.Afts_LabelEntryKey_LabelOpenconfigmplstypesmplslabelenum{
+						LabelOpenconfigmplstypesmplslabelenum: enums.OpenconfigMplsTypesMplsLabelEnum_OPENCONFIGMPLSTYPESMPLSLABELENUM_IMPLICIT_NULL,
+					},
+				},
+			},
+		},
+		wantFails: []*OpResult{{
+			ID: 42,
+			Op: &spb.AFTOperation{
+				Id: 42,
+				Entry: &spb.AFTOperation_Mpls{
+					Mpls: &aftpb.Afts_LabelEntryKey{
+						Label: &aftpb.Afts_LabelEntryKey_LabelOpenconfigmplstypesmplslabelenum{
+							LabelOpenconfigmplstypesmplslabelenum: enums.OpenconfigMplsTypesMplsLabelEnum_OPENCONFIGMPLSTYPESMPLSLABELENUM_IMPLICIT_NULL,
+						},
+					},
+				},
+			},
+			Error: "unsupported label type *gribi_aft.Afts_LabelEntryKey, only uint64 labels are supported, label_openconfigmplstypesmplslabelenum:OPENCONFIGMPLSTYPESMPLSLABELENUM_IMPLICIT_NULL",
+		}},
 	}, {
 		desc: "delete MPLS",
 		inRIB: func() *RIB {


### PR DESCRIPTION
```
commit f04e812ed27e34bebdf28c6b04e57d7675f98c61
Author: Rob Shakir <robjs@google.com>
Date:   Tue Nov 29 16:36:26 2022 -0800

    Check label type.
    
      * (M) rib/rib.go
      * (M) rib/rib_test.go
        - Add a check that we are looking at only uint64 labels.

commit 167dae2044c0ef9443b88e33b16aa314645b8298
Author: Rob Shakir <robjs@google.com>
Date:   Tue Nov 29 16:27:10 2022 -0800

    Add support for deleting MPLS entries.
    
      * (M) compliance/compliance.go
      * (M) compliance/mpls.go
        - Add new compliance test for adding and deleting MPLS entries.
      * (M) device/device.go
        - Add parsing for MPLS entries to the telemetry handler.
      * (M) rib/rib.go
      * (M) rib/rib_test.go
        - Add support for deleting a label enry from the MPLS LRIB. We
          only support entries that have a uint specified label, rather
          than explicitly named ones.
```
