### PR TITLE
TestOperationIsolation: prevent race condition during starting gribi session

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -1296,6 +1296,8 @@ func TestOperationIsolation(c *fluent.GRIBIClient, t testing.TB, opts ...TestOpt
 		WithPersistence()
 	clientA.Start(context.Background(), t)
 	clientA.StartSending(context.Background(), t)
+	clientAErr := awaitTimeout(context.Background(), clientA, t, time.Minute)
+	chk.HasNRecvErrors(t, clientAErr, 0)
 
 	clientB.Connection().WithInitialElectionID(electionID.Load(), 0).
 		WithRedundancyMode(fluent.ElectedPrimaryClient).


### PR DESCRIPTION
The current test start both clients at the same time that can lead to a race condition (flaky test). Added a Check for clientA reply before starting clientB. 