### PR TITLE
Handle rib-ack op responses received after a fib-ack

### DIFF
--- a/client/gribiclient_test.go
+++ b/client/gribiclient_test.go
@@ -701,6 +701,46 @@ func TestHandleModifyResponse(t *testing.T) {
 			ProgrammingResult: spb.AFTResult_FAILED,
 			Details:           &OpDetailsResults{},
 		}},
+	}, {
+		desc: "AckType RIB_AND_FIB_ACK, receive AFTResult_FIB_PROGRAMMED before AFTResult_RIB_PROGRAMMED",
+		inClient: &Client{
+			qs: &clientQs{
+				pendq: &pendingQueue{
+					Ops: map[uint64]*PendingOp{
+						1: {
+							Timestamp: 42,
+							Op:        &spb.AFTOperation{Id: 1},
+						},
+					},
+				},
+				sending: &atomic.Bool{},
+			},
+			state: &clientState{
+				SessParams: &spb.SessionParameters{
+					AckType: spb.SessionParameters_RIB_AND_FIB_ACK,
+				},
+			},
+		},
+		inResponse: &spb.ModifyResponse{
+			Result: []*spb.AFTResult{
+				{
+					Id:     1,
+					Status: spb.AFTResult_FIB_PROGRAMMED,
+				}, {
+					Id:     1,
+					Status: spb.AFTResult_RIB_PROGRAMMED,
+				}},
+		},
+		wantResults: []*OpResult{{
+			Timestamp:         42,
+			OperationID:       1,
+			ProgrammingResult: spb.AFTResult_FIB_PROGRAMMED,
+			Details:           &OpDetailsResults{},
+		}, {
+			Timestamp:         42,
+			OperationID:       1,
+			ProgrammingResult: spb.AFTResult_RIB_PROGRAMMED,
+		}},
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Previously, if a client in RIB_AND_FIB_ACK mode received a rib-ack response for an op after receiving the fib-ack, the client would return a "op not found" error. This happened because the client deleted the op from the pending op queue while handing the fib-ack, and then the client would not find the op in the pending queue when processing the following rib-ack

Normally, the client expects the rib-ack to precede the fib-ack, so this problem only happens in the edge case where the fib-ack is received by the client before the rib-ack.

As a workaround, the client will now return a generic result without op detail to the rib-ack. The client can't fetch op details for the rib-ack because the op will have already been deleted by the fib-ack response handling. In the future, we can consider caching pending ops to ensure the details are available.