### PR TITLE
Add support for retreiving from a remote RIB.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/golang/glog v1.1.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
-	github.com/kr/pretty v0.3.1
 	github.com/openconfig/gnmi v0.10.0
 	github.com/openconfig/goyang v1.4.1
 	github.com/openconfig/gribi v1.0.0
@@ -32,7 +31,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/k-sone/critbitgo v1.4.0 // indirect
 	github.com/kentik/patricia v1.2.0 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -44,7 +42,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,13 @@ require (
 	github.com/golang/glog v1.1.2
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
+	github.com/kr/pretty v0.3.1
 	github.com/openconfig/gnmi v0.10.0
 	github.com/openconfig/goyang v1.4.1
 	github.com/openconfig/gribi v1.0.0
 	github.com/openconfig/lemming v0.3.2-0.20230914210403-c6484d12af0a
 	github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07
-	github.com/openconfig/ygot v0.29.10
+	github.com/openconfig/ygot v0.29.11-0.20230922074452-052ed885651c
 	go.uber.org/atomic v1.10.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d
 	google.golang.org/grpc v1.58.0-dev
@@ -31,6 +32,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/k-sone/critbitgo v1.4.0 // indirect
 	github.com/kentik/patricia v1.2.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -42,6 +44,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openconfig/gribi v1.0.0
 	github.com/openconfig/lemming v0.3.2-0.20230914210403-c6484d12af0a
 	github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07
-	github.com/openconfig/ygot v0.29.11-0.20230922074452-052ed885651c
+	github.com/openconfig/ygot v0.29.11-0.20230922181344-6c3af4108a57
 	go.uber.org/atomic v1.10.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d
 	google.golang.org/grpc v1.58.0-dev

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,8 @@ github.com/openconfig/ygot v0.29.10 h1:FRZXxyeCdiJXz6uat5uOm3Hlg+PUu2N0mY+eiva12
 github.com/openconfig/ygot v0.29.10/go.mod h1:RNnn1ytQ8GZV5LPts36l0cyoRjsYYpruiruJEvmU2sg=
 github.com/openconfig/ygot v0.29.11-0.20230922074452-052ed885651c h1:0rE/tRnck61Guj+zkButSrb1VMWtDP0xX4cmanEDHL4=
 github.com/openconfig/ygot v0.29.11-0.20230922074452-052ed885651c/go.mod h1:RNnn1ytQ8GZV5LPts36l0cyoRjsYYpruiruJEvmU2sg=
+github.com/openconfig/ygot v0.29.11-0.20230922181344-6c3af4108a57 h1:z7bNYTNR1HzxYQNVwBUaf0veA4j4vuTBW7mTLRW4M1w=
+github.com/openconfig/ygot v0.29.11-0.20230922181344-6c3af4108a57/go.mod h1:RNnn1ytQ8GZV5LPts36l0cyoRjsYYpruiruJEvmU2sg=
 github.com/p4lang/p4runtime v1.4.0-rc.5.0.20220728214547-13f0d02a521e h1:AfZKoikDXbZ7zWvO/lvCRzLo7i6lM+gNleYVMxPiWyQ=
 github.com/p4lang/p4runtime v1.4.0-rc.5.0.20220728214547-13f0d02a521e/go.mod h1:m9laObIMXM9N1ElGXijc66/MSM5eheZJLRLxg/TG+fU=
 github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=

--- a/go.sum
+++ b/go.sum
@@ -55,7 +55,6 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -172,11 +171,9 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
-github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
-github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -211,10 +208,6 @@ github.com/openconfig/ygnmi v0.8.7/go.mod h1:7up6qc9l9G4+Cfo37gzO0D7+2g4yqyW+xzh
 github.com/openconfig/ygot v0.6.0/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQSmIhqwAs=
 github.com/openconfig/ygot v0.10.4/go.mod h1:oCQNdXnv7dWc8scTDgoFkauv1wwplJn5HspHcjlxSAQ=
 github.com/openconfig/ygot v0.13.2/go.mod h1:kJN0yCXIH07dOXvNBEFm3XxXdnDD5NI6K99tnD5x49c=
-github.com/openconfig/ygot v0.29.10 h1:FRZXxyeCdiJXz6uat5uOm3Hlg+PUu2N0mY+eiva12MI=
-github.com/openconfig/ygot v0.29.10/go.mod h1:RNnn1ytQ8GZV5LPts36l0cyoRjsYYpruiruJEvmU2sg=
-github.com/openconfig/ygot v0.29.11-0.20230922074452-052ed885651c h1:0rE/tRnck61Guj+zkButSrb1VMWtDP0xX4cmanEDHL4=
-github.com/openconfig/ygot v0.29.11-0.20230922074452-052ed885651c/go.mod h1:RNnn1ytQ8GZV5LPts36l0cyoRjsYYpruiruJEvmU2sg=
 github.com/openconfig/ygot v0.29.11-0.20230922181344-6c3af4108a57 h1:z7bNYTNR1HzxYQNVwBUaf0veA4j4vuTBW7mTLRW4M1w=
 github.com/openconfig/ygot v0.29.11-0.20230922181344-6c3af4108a57/go.mod h1:RNnn1ytQ8GZV5LPts36l0cyoRjsYYpruiruJEvmU2sg=
 github.com/p4lang/p4runtime v1.4.0-rc.5.0.20220728214547-13f0d02a521e h1:AfZKoikDXbZ7zWvO/lvCRzLo7i6lM+gNleYVMxPiWyQ=
@@ -222,7 +215,6 @@ github.com/p4lang/p4runtime v1.4.0-rc.5.0.20220728214547-13f0d02a521e/go.mod h1:
 github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.0.9 h1:uH2qQXheeefCCkuBBSLi7jCiSmj3VRh2+Goq2N7Xxu0=
 github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
-github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
@@ -232,7 +224,6 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
-github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,7 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -171,9 +172,11 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -210,11 +213,14 @@ github.com/openconfig/ygot v0.10.4/go.mod h1:oCQNdXnv7dWc8scTDgoFkauv1wwplJn5Hsp
 github.com/openconfig/ygot v0.13.2/go.mod h1:kJN0yCXIH07dOXvNBEFm3XxXdnDD5NI6K99tnD5x49c=
 github.com/openconfig/ygot v0.29.10 h1:FRZXxyeCdiJXz6uat5uOm3Hlg+PUu2N0mY+eiva12MI=
 github.com/openconfig/ygot v0.29.10/go.mod h1:RNnn1ytQ8GZV5LPts36l0cyoRjsYYpruiruJEvmU2sg=
+github.com/openconfig/ygot v0.29.11-0.20230922074452-052ed885651c h1:0rE/tRnck61Guj+zkButSrb1VMWtDP0xX4cmanEDHL4=
+github.com/openconfig/ygot v0.29.11-0.20230922074452-052ed885651c/go.mod h1:RNnn1ytQ8GZV5LPts36l0cyoRjsYYpruiruJEvmU2sg=
 github.com/p4lang/p4runtime v1.4.0-rc.5.0.20220728214547-13f0d02a521e h1:AfZKoikDXbZ7zWvO/lvCRzLo7i6lM+gNleYVMxPiWyQ=
 github.com/p4lang/p4runtime v1.4.0-rc.5.0.20220728214547-13f0d02a521e/go.mod h1:m9laObIMXM9N1ElGXijc66/MSM5eheZJLRLxg/TG+fU=
 github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.0.9 h1:uH2qQXheeefCCkuBBSLi7jCiSmj3VRh2+Goq2N7Xxu0=
 github.com/pelletier/go-toml/v2 v2.0.9/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
@@ -224,6 +230,7 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/rib/helpers.go
+++ b/rib/helpers.go
@@ -26,7 +26,7 @@ import (
 
 // FromGetResponses returns a RIB from a slice of gRIBI GetResponse messages.
 // The supplied defaultName is used as the default network instance name.
-func FromGetResponses(defaultName string, responses []*spb.GetResponse) (*RIB, error) {
+func FromGetResponses(defaultName string, responses []*spb.GetResponse, opt ...RIBOpt) (*RIB, error) {
 	r := New(defaultName)
 	niAFTs := map[string]*aftpb.Afts{}
 

--- a/rib/reconciler/reconcile_test.go
+++ b/rib/reconciler/reconcile_test.go
@@ -1,6 +1,7 @@
 package reconciler
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -16,7 +17,7 @@ func TestLocalRIB(t *testing.T) {
 		}
 
 		want := rib.New("DEFAULT")
-		got, err := l.Get()
+		got, err := l.Get(context.Background())
 		if err != nil {
 			t.Fatalf("(*LocalRIB).Get(): did not get expected error, got: %v, want: nil", err)
 		}

--- a/rib/reconciler/remote.go
+++ b/rib/reconciler/remote.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/openconfig/gribigo/client"
 	"github.com/openconfig/gribigo/rib"
-	"google.golang.org/protobuf/encoding/prototext"
 
 	spb "github.com/openconfig/gribi/v1/proto/service"
 )
@@ -56,8 +55,6 @@ func (r *RemoteRIB) Get(ctx context.Context) (*rib.RIB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot get remote RIB, %v", err)
 	}
-
-	fmt.Printf("%s\n", prototext.Format(resp))
 
 	// We always disable the RIB checking function because we want to see entries that have
 	// not got valid references so that we can reconcile them.

--- a/rib/reconciler/remote.go
+++ b/rib/reconciler/remote.go
@@ -1,0 +1,70 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openconfig/gribigo/client"
+	"github.com/openconfig/gribigo/rib"
+	"google.golang.org/protobuf/encoding/prototext"
+
+	spb "github.com/openconfig/gribi/v1/proto/service"
+)
+
+// RemoteRIB implements the RIBTarget interface and wraps a remote gRIBI RIB.
+// The contents are accessed via the gRIBI gRPC API.
+type RemoteRIB struct {
+	c *client.Client
+
+	defaultName string
+}
+
+// NewRemoteRIB returns a new remote gRIBI RIB. The context supplied is used to
+// dial the remote gRIBI server at the address 'addr'. the 'defName' argument
+// is used to identify the name of the default network instance on the server.
+func NewRemoteRIB(ctx context.Context, defName, addr string) (*RemoteRIB, error) {
+	gc, err := client.New()
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gRIBI client, %v", err)
+	}
+
+	r := &RemoteRIB{
+		c:           gc,
+		defaultName: defName,
+	}
+
+	if err := r.c.Dial(ctx, addr); err != nil {
+		return nil, fmt.Errorf("cannot dial remote server, %v", err)
+	}
+	return r, nil
+}
+
+// CleanUp closes the remote connection to the gRIBI server.
+func (r *RemoteRIB) CleanUp() {
+	r.c.Close()
+}
+
+// Get retrieves the contents of the remote gRIBI server's RIB and returns it as a
+// gRIBIgo RIB struct. The context is used for a Get RPC call to the remote server.
+func (r *RemoteRIB) Get(ctx context.Context) (*rib.RIB, error) {
+	resp, err := r.c.Get(ctx, &spb.GetRequest{
+		NetworkInstance: &spb.GetRequest_All{
+			All: &spb.Empty{},
+		},
+		Aft: spb.AFTType_ALL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot get remote RIB, %v", err)
+	}
+
+	fmt.Printf("%s\n", prototext.Format(resp))
+
+	// We always disable the RIB checking function because we want to see entries that have
+	// not got valid references so that we can reconcile them.
+	remRIB, err := rib.FromGetResponses(r.defaultName, []*spb.GetResponse{resp}, rib.DisableRIBCheckFn())
+	if err != nil {
+		return nil, fmt.Errorf("cannot build remote RIB from responses, %v", err)
+	}
+
+	return remRIB, nil
+}

--- a/rib/reconciler/remote_test.go
+++ b/rib/reconciler/remote_test.go
@@ -1,0 +1,187 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openconfig/gribigo/aft"
+	"github.com/openconfig/gribigo/rib"
+	"github.com/openconfig/gribigo/server"
+	"github.com/openconfig/gribigo/testcommon"
+	"github.com/openconfig/ygot/ygot"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+
+	spb "github.com/openconfig/gribi/v1/proto/service"
+)
+
+func newServer(t *testing.T, r *rib.RIB) (string, func()) {
+	creds, err := credentials.NewServerTLSFromFile(testcommon.TLSCreds())
+	if err != nil {
+		t.Fatalf("cannot load TLS credentials, got err: %v", err)
+	}
+	srv := grpc.NewServer(grpc.Creds(creds))
+	s, err := server.NewFake()
+	if err != nil {
+		t.Fatalf("cannot create server, got err: %v", err)
+	}
+	s.InjectRIB(r)
+
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("cannot create listener, got err: %v", err)
+	}
+	spb.RegisterGRIBIServer(srv, s)
+
+	go srv.Serve(l)
+	return l.Addr().String(), srv.Stop
+}
+
+func TestNewRemoteRIB(t *testing.T) {
+	tests := []struct {
+		desc           string
+		inDefName      string
+		inAddrOverride string
+		wantErr        bool
+	}{{
+		desc:      "successful dial",
+		inDefName: "DEFAULT",
+	}, {
+		desc:           "unsuccessful dial",
+		inDefName:      "DEFAULT",
+		inAddrOverride: "invalid.addr:999999",
+		wantErr:        true,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			addr, stop := newServer(t, nil)
+			defer stop()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			if tt.inAddrOverride != "" {
+				addr = tt.inAddrOverride
+			}
+
+			if _, err := NewRemoteRIB(ctx, tt.inDefName, addr); (err != nil) != tt.wantErr {
+				t.Fatalf("NewRemoteRIB(ctx, %s, %s): did not get expected error, got: %v, wantErr? %v", tt.inDefName, addr, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+type badGRIBI struct {
+	*spb.UnimplementedGRIBIServer
+}
+
+func (b *badGRIBI) Get(_ *spb.GetRequest, _ spb.GRIBI_GetServer) error {
+	return status.Errorf(codes.Unimplemented, "RPC unimplemented")
+}
+
+func newBadServer(t *testing.T, r *rib.RIB) (string, func()) {
+	creds, err := credentials.NewServerTLSFromFile(testcommon.TLSCreds())
+	if err != nil {
+		t.Fatalf("cannot load TLS credentials, got err: %v", err)
+	}
+	srv := grpc.NewServer(grpc.Creds(creds))
+	s := &badGRIBI{}
+
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("cannot create listener, got err: %v", err)
+	}
+	spb.RegisterGRIBIServer(srv, s)
+
+	go srv.Serve(l)
+	return l.Addr().String(), srv.Stop
+
+}
+
+func TestGet(t *testing.T) {
+	dn := "DEFAULT"
+	tests := []struct {
+		desc            string
+		inDefName       string
+		inServer        func(*testing.T, *rib.RIB) (string, func())
+		inInjectedRIB   *rib.RIB
+		wantRIBContents map[string]*aft.RIB
+		wantErr         bool
+	}{{
+		desc:      "cannot get RIB",
+		inDefName: "DEFAULT",
+		inServer:  newBadServer,
+		wantErr:   true,
+	}, {
+		desc:      "successfully got RIB",
+		inDefName: dn,
+		inServer:  newServer,
+		inInjectedRIB: func() *rib.RIB {
+			r := rib.NewFake(dn)
+			if err := r.InjectNH(dn, 1); err != nil {
+				t.Fatalf("cannot add NH, %v", err)
+			}
+			if err := r.InjectNHG(dn, 1, map[uint64]uint64{1: 1}); err != nil {
+				t.Fatalf("cannot add NHG, %v", err)
+			}
+			if err := r.InjectIPv4(dn, "1.0.0.0/24", 1); err != nil {
+				t.Fatalf("cannot add IPv4, %v", err)
+			}
+			return r.RIB()
+		}(),
+		wantRIBContents: map[string]*aft.RIB{
+			dn: func() *aft.RIB {
+				r := &aft.RIB{}
+				a := r.GetOrCreateAfts()
+				a.GetOrCreateIpv4Entry("1.0.0.0/24").NextHopGroup = ygot.Uint64(1)
+				a.GetOrCreateNextHopGroup(1).GetOrCreateNextHop(1).Weight = ygot.Uint64(1)
+				a.GetOrCreateNextHop(1)
+				return r
+			}(),
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			addr, stop := tt.inServer(t, tt.inInjectedRIB)
+			defer stop()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			rr, err := NewRemoteRIB(ctx, tt.inDefName, addr)
+			if err != nil {
+				t.Fatalf("NewRemoteRIB(_, %s, %s): cannot connect, got err: %v", tt.inDefName, addr, err)
+			}
+
+			got, err := rr.Get(ctx)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("(*RemoteRIB).Get(ctx): did not get expected err, got: %v, wantErr? %v", err, tt.wantErr)
+			}
+
+			if err != nil {
+				return
+			}
+
+			// We can't introspect the private RIB contents, so make a copy to introspect.
+			gotContents, err := got.RIBContents()
+			if err != nil {
+				t.Fatalf("(*RemoteRIB).Get(ctx).RIBContents(): can't introspect RIB, err: %v", err)
+			}
+			fmt.Printf("%s\n", got.String())
+			fmt.Printf("%s\n", tt.inInjectedRIB)
+
+			if diff := cmp.Diff(gotContents, tt.wantRIBContents); diff != "" {
+				t.Fatalf("(*RemoteRIB).Get(ctx): did not get expected contents, diff(-got,+want):\n%s", diff)
+			}
+
+		})
+	}
+}

--- a/rib/reconciler/remote_test.go
+++ b/rib/reconciler/remote_test.go
@@ -2,7 +2,6 @@ package reconciler
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -175,8 +174,6 @@ func TestGet(t *testing.T) {
 			if err != nil {
 				t.Fatalf("(*RemoteRIB).Get(ctx).RIBContents(): can't introspect RIB, err: %v", err)
 			}
-			fmt.Printf("%s\n", got.String())
-			fmt.Printf("%s\n", tt.inInjectedRIB)
 
 			if diff := cmp.Diff(gotContents, tt.wantRIBContents); diff != "" {
 				t.Fatalf("(*RemoteRIB).Get(ctx): did not get expected contents, diff(-got,+want):\n%s", diff)

--- a/rib/rib.go
+++ b/rib/rib.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-	"github.com/kr/pretty"
 	"github.com/openconfig/gnmi/value"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/gribigo/aft"
@@ -34,7 +33,6 @@ import (
 	"github.com/openconfig/ygot/ytypes"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
@@ -1820,8 +1818,6 @@ func concreteNextHopProto(e *aft.Afts_NextHop) (*aftpb.Afts_NextHopKey, error) {
 // concreteNextHopGroupProto takes the input NextHopGroup GoStruct and returns it as a gRIBI
 // NextHopGroupEntryKey protobuf. It returns an error if the protobuf cannot be marshalled.
 func concreteNextHopGroupProto(e *aft.Afts_NextHopGroup) (*aftpb.Afts_NextHopGroupKey, error) {
-	fmt.Printf("input: %v\n", e)
-	fmt.Printf("val: %d\n", *e.Id)
 	nhgproto := &aftpb.Afts_NextHopGroup{}
 	if err := protoFromGoStruct(e, &gpb.Path{
 		Elem: []*gpb.PathElem{{
@@ -1834,7 +1830,6 @@ func concreteNextHopGroupProto(e *aft.Afts_NextHopGroup) (*aftpb.Afts_NextHopGro
 	}, nhgproto); err != nil {
 		return nil, fmt.Errorf("cannot marshal next-hop index %d, %v", e.GetId(), err)
 	}
-	fmt.Printf("concrete nhg: %s\n", prototext.Format(nhgproto))
 	return &aftpb.Afts_NextHopGroupKey{
 		Id:           *e.Id,
 		NextHopGroup: nhgproto,
@@ -1858,7 +1853,6 @@ func protoFromGoStruct(s ygot.ValidatedGoStruct, prefix *gpb.Path, pb proto.Mess
 			vals[u.Path] = u.Val
 		}
 	}
-	pretty.Printf("vals: %s\n", vals)
 
 	if err := protomap.ProtoFromPaths(pb, vals,
 		protomap.ProtobufMessagePrefix(prefix),
@@ -1867,8 +1861,6 @@ func protoFromGoStruct(s ygot.ValidatedGoStruct, prefix *gpb.Path, pb proto.Mess
 	); err != nil {
 		return fmt.Errorf("cannot unmarshal gNMI paths, %v", err)
 	}
-
-	fmt.Printf("unmarshalled: %s\n", prototext.Format(pb))
 
 	return nil
 }

--- a/rib/rib_test.go
+++ b/rib/rib_test.go
@@ -851,6 +851,35 @@ func TestIndividualDeleteEntryFunctions(t *testing.T) {
 	}
 }
 
+func TestConcreteNHGProto(t *testing.T) {
+	tests := []struct {
+		desc    string
+		inEntry *aft.Afts_NextHopGroup
+		want    *aftpb.Afts_NextHopGroupKey
+		wantErr bool
+	}{{
+		desc: "populated nhg",
+		inEntry: func() *aft.Afts_NextHopGroup {
+			a := &aft.Afts_NextHopGroup{}
+			a.Id = ygot.Uint64(1)
+			a.GetOrCreateNextHop(1).Weight = ygot.Uint64(1)
+			return a
+		}(),
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := concreteNextHopGroupProto(tt.inEntry)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("did not get expected error, got: %v, want: %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(got, tt.want, protocmp.Transform(), cmpopts.EquateEmpty()); diff != "" {
+				t.Fatalf("did not get expected proto, diff(-got,+want):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestConcreteIPv4Proto(t *testing.T) {
 	tests := []struct {
 		desc    string
@@ -4228,4 +4257,103 @@ func TestFlush(t *testing.T) {
 			t.Fatalf("did not remove all IPv4 entries, got: %d, want: 0", l)
 		}
 	}
+}
+
+func TestRIBContents(t *testing.T) {
+	tests := []struct {
+		desc    string
+		inRIB   *RIB
+		want    map[string]*aft.RIB
+		wantErr bool
+	}{{
+		desc: "one NI",
+		inRIB: &RIB{
+			niRIB: map[string]*RIBHolder{
+				"default": {
+					r: &aft.RIB{
+						Afts: &aft.Afts{
+							Ipv4Entry: map[string]*aft.Afts_Ipv4Entry{
+								"1.0.0.0/24": {
+									Prefix: ygot.String("1.0.0.0/24"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		want: map[string]*aft.RIB{
+			"default": {
+				Afts: &aft.Afts{
+					Ipv4Entry: map[string]*aft.Afts_Ipv4Entry{
+						"1.0.0.0/24": {
+							Prefix: ygot.String("1.0.0.0/24"),
+						},
+					},
+				},
+			},
+		},
+	}, {
+		desc: "two NIs",
+		inRIB: &RIB{
+			niRIB: map[string]*RIBHolder{
+				"default": {
+					r: &aft.RIB{
+						Afts: &aft.Afts{
+							Ipv4Entry: map[string]*aft.Afts_Ipv4Entry{
+								"1.0.0.0/24": {
+									Prefix: ygot.String("1.0.0.0/24"),
+								},
+							},
+						},
+					},
+				},
+				"pepsicola": {
+					r: &aft.RIB{
+						Afts: &aft.Afts{
+							NextHop: map[uint64]*aft.Afts_NextHop{
+								1: {
+									Index: ygot.Uint64(1),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		want: map[string]*aft.RIB{
+			"default": {
+				Afts: &aft.Afts{
+					Ipv4Entry: map[string]*aft.Afts_Ipv4Entry{
+						"1.0.0.0/24": {
+							Prefix: ygot.String("1.0.0.0/24"),
+						},
+					},
+				},
+			},
+			"pepsicola": {
+				Afts: &aft.Afts{
+					NextHop: map[uint64]*aft.Afts_NextHop{
+						1: {
+							Index: ygot.Uint64(1),
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := tt.inRIB.RIBContents()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("(*RIB).RIBContents(): did not get expected error, got: %v, wantErr? %v", err, tt.wantErr)
+			}
+
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Fatalf("(*RIB).RIBContents(): did not get expected contents, diff(-got,+want):\n%s", diff)
+			}
+		})
+	}
+
 }

--- a/rib/rib_test.go
+++ b/rib/rib_test.go
@@ -865,6 +865,17 @@ func TestConcreteNHGProto(t *testing.T) {
 			a.GetOrCreateNextHop(1).Weight = ygot.Uint64(1)
 			return a
 		}(),
+		want: &aftpb.Afts_NextHopGroupKey{
+			Id: 1,
+			NextHopGroup: &aftpb.Afts_NextHopGroup{
+				NextHop: []*aftpb.Afts_NextHopGroup_NextHopKey{{
+					Index: 1,
+					NextHop: &aftpb.Afts_NextHopGroup_NextHop{
+						Weight: &wpb.UintValue{Value: 1},
+					},
+				}},
+			},
+		},
 	}}
 
 	for _, tt := range tests {
@@ -3205,8 +3216,15 @@ func TestGetRIB(t *testing.T) {
 				NetworkInstance: "VRF-42",
 				Entry: &spb.AFTEntry_NextHopGroup{
 					NextHopGroup: &aftpb.Afts_NextHopGroupKey{
-						Id:           42,
-						NextHopGroup: &aftpb.Afts_NextHopGroup{},
+						Id: 42,
+						NextHopGroup: &aftpb.Afts_NextHopGroup{
+							NextHop: []*aftpb.Afts_NextHopGroup_NextHopKey{{
+								Index: 1,
+								NextHop: &aftpb.Afts_NextHopGroup_NextHop{
+									Weight: &wpb.UintValue{Value: 1},
+								},
+							}},
+						},
 					},
 				},
 			}},


### PR DESCRIPTION
```
commit 297adef3ac06a2cf72a988c6c050c9fb757caa8c
Author: Rob Shakir <robjs@google.com>
Date:   Fri Sep 22 20:49:01 2023 +0000

    Add support for retrieving a RIB from a remote source.
    
     * (M) go.{mod,sum}
      - Move to non-release version of ygot to get new `protomap` features.
     * (M) rib/remote.go
      - Add support for a RIB that is accessed via the `Get` RPC rather than
        locally.
     * (M) rib/rib(_test).go
      - Add a mechanism to retrieve RIB contents, improve testing.

commit 197d34f65212473220545d930d5a0f537af673f4
Author: Rob Shakir <robjs@google.com>
Date:   Fri Sep 22 07:50:51 2023 +0000

    Support retrieving from a remote RIB.
```
