### PR TITLE
Add merge to Ops and ReconcileOps; UseStub to client.

### DIFF
--- a/rib/reconciler/reconcile.go
+++ b/rib/reconciler/reconcile.go
@@ -134,6 +134,16 @@ type Ops struct {
 	TopLevel []*spb.AFTOperation
 }
 
+// Merge adds the operations from the "in" operations to the receiver ops.
+func (o *Ops) Merge(in *Ops) {
+	if in == nil {
+		return
+	}
+	o.NH = append(o.NH, in.NH...)
+	o.NHG = append(o.NHG, in.NHG...)
+	o.TopLevel = append(o.TopLevel, in.TopLevel...)
+}
+
 // ReconcileOps stores the operations that are required for a specific reconciliation
 // run.
 type ReconcileOps struct {
@@ -144,6 +154,16 @@ type ReconcileOps struct {
 	Replace *Ops
 	// Delete stores the operations that are removing entries.
 	Delete *Ops
+}
+
+// Merge adds the operations from the "in" operations to the receiver operations.
+func (r *ReconcileOps) Merge(in *ReconcileOps) {
+	if in == nil {
+		return
+	}
+	r.Add.Merge(in.Add)
+	r.Replace.Merge(in.Replace)
+	r.Delete.Merge(in.Delete)
 }
 
 // NewReconcileOps returns a new reconcileOps struct with the fields initialised.

--- a/rib/reconciler/remote.go
+++ b/rib/reconciler/remote.go
@@ -38,6 +38,23 @@ func NewRemoteRIB(ctx context.Context, defName, addr string) (*RemoteRIB, error)
 	return r, nil
 }
 
+// NewRemoteRIBWithStub creates a new remote RIB using the specified default network
+// instance name, and the provided stub client. It returns an error if the
+// client cannot be created.
+func NewRemoteRIBWithStub(defName string, stub spb.GRIBIClient) (*RemoteRIB, error) {
+	c, err := client.New()
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gRIBI client, %v", err)
+	}
+	if err := c.UseStub(stub); err != nil {
+		return nil, fmt.Errorf("cannot set gRIBI client within wrapper client, %v", err)
+	}
+	return &RemoteRIB{
+		c:           c,
+		defaultName: defName,
+	}, nil
+}
+
 // CleanUp closes the remote connection to the gRIBI server.
 func (r *RemoteRIB) CleanUp() {
 	r.c.Close()


### PR DESCRIPTION
```
 * (M) rib/reconcile/reconcile(_test)?.go
   - Add support for merging Ops and ReconcileOps instances together.
 * (M) rib/reconcile/remote(_rtest)?.go
   - Add support for a client that takes an existing gRIBI client stub.
```
