### PR TITLE
Add `IsEmpty` functions for `Ops` and `ReconcileOps`.

### DIFF
--- a/client/gribiclient.go
+++ b/client/gribiclient.go
@@ -391,7 +391,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	informDone := func(who string) {
 		select {
 		case c.doneCh <- struct{}{}:
-			log.Infof("writing to done channel, requsted by %s", who)
+			log.Infof("writing to done channel, requested by %s", who)
 		default:
 			log.Infof("dropped message informing caller the client is done.")
 		}

--- a/rib/reconciler/reconcile.go
+++ b/rib/reconciler/reconcile.go
@@ -146,7 +146,7 @@ func (o *Ops) Merge(in *Ops) {
 
 // IsEmpty determines whether the specified Ops contains any operations.
 func (o *Ops) IsEmpty() bool {
-	return len(o.NH) == 0 && len(o.NHG) == 0 && len(o.TopLevel) == 0
+	return o == nil || len(o.NH) == 0 && len(o.NHG) == 0 && len(o.TopLevel) == 0
 }
 
 // ReconcileOps stores the operations that are required for a specific reconciliation
@@ -173,7 +173,7 @@ func (r *ReconcileOps) Merge(in *ReconcileOps) {
 
 // IsEmpty determines whether the specified ReconcileOps contains any operations.
 func (r *ReconcileOps) IsEmpty() bool {
-	return r.Add.IsEmpty() && r.Delete.IsEmpty() && r.Replace.IsEmpty()
+	return r == nil || r.Add.IsEmpty() && r.Delete.IsEmpty() && r.Replace.IsEmpty()
 }
 
 // NewReconcileOps returns a new reconcileOps struct with the fields initialised.

--- a/rib/reconciler/reconcile.go
+++ b/rib/reconciler/reconcile.go
@@ -144,6 +144,11 @@ func (o *Ops) Merge(in *Ops) {
 	o.TopLevel = append(o.TopLevel, in.TopLevel...)
 }
 
+// IsEmpty determines whether the specified Ops contains any operations.
+func (o *Ops) IsEmpty() bool {
+	return len(o.NH) == 0 && len(o.NHG) == 0 && len(o.TopLevel) == 0
+}
+
 // ReconcileOps stores the operations that are required for a specific reconciliation
 // run.
 type ReconcileOps struct {
@@ -164,6 +169,11 @@ func (r *ReconcileOps) Merge(in *ReconcileOps) {
 	r.Add.Merge(in.Add)
 	r.Replace.Merge(in.Replace)
 	r.Delete.Merge(in.Delete)
+}
+
+// IsEmpty determines whether the specified ReconcileOps contains any operations.
+func (r *ReconcileOps) IsEmpty() bool {
+	return r.Add.IsEmpty() && r.Delete.IsEmpty() && r.Replace.IsEmpty()
 }
 
 // NewReconcileOps returns a new reconcileOps struct with the fields initialised.

--- a/rib/reconciler/reconcile_test.go
+++ b/rib/reconciler/reconcile_test.go
@@ -1599,6 +1599,9 @@ func TestReconcileOpsIsEmpty(t *testing.T) {
 		in   *ReconcileOps
 		want bool
 	}{{
+		desc: "nil",
+		want: true,
+	}, {
 		desc: "empty",
 		in:   NewReconcileOps(),
 		want: true,
@@ -1657,6 +1660,9 @@ func TestOpsIsEmpty(t *testing.T) {
 	}{{
 		desc: "empty",
 		in:   &Ops{},
+		want: true,
+	}, {
+		desc: "nil",
 		want: true,
 	}, {
 		desc: "not empty: top-level",

--- a/rib/reconciler/reconcile_test.go
+++ b/rib/reconciler/reconcile_test.go
@@ -1592,3 +1592,97 @@ func TestMergeReconcileOps(t *testing.T) {
 		})
 	}
 }
+
+func TestReconcileOpsIsEmpty(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   *ReconcileOps
+		want bool
+	}{{
+		desc: "empty",
+		in:   NewReconcileOps(),
+		want: true,
+	}, {
+		desc: "not empty: add",
+		in: &ReconcileOps{
+			Add: &Ops{
+				NH:       []*spb.AFTOperation{{}},
+				NHG:      []*spb.AFTOperation{{}},
+				TopLevel: []*spb.AFTOperation{{}},
+			},
+			Delete:  &Ops{},
+			Replace: &Ops{},
+		},
+		want: false,
+	}, {
+		desc: "not empty: delete",
+		in: &ReconcileOps{
+			Add: &Ops{},
+			Delete: &Ops{
+				NH:       []*spb.AFTOperation{{}},
+				NHG:      []*spb.AFTOperation{{}},
+				TopLevel: []*spb.AFTOperation{{}},
+			},
+			Replace: &Ops{},
+		},
+		want: false,
+	}, {
+		desc: "not empty: replace",
+		in: &ReconcileOps{
+			Add:    &Ops{},
+			Delete: &Ops{},
+			Replace: &Ops{
+				NH:       []*spb.AFTOperation{{}},
+				NHG:      []*spb.AFTOperation{{}},
+				TopLevel: []*spb.AFTOperation{{}},
+			},
+		},
+		want: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := tt.in.IsEmpty(); got != tt.want {
+				t.Fatalf("(%v).IsEmpty(): did not get expected result, got: %v, want: %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpsIsEmpty(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   *Ops
+		want bool
+	}{{
+		desc: "empty",
+		in:   &Ops{},
+		want: true,
+	}, {
+		desc: "not empty: top-level",
+		in: &Ops{
+			TopLevel: []*spb.AFTOperation{{}},
+		},
+		want: false,
+	}, {
+		desc: "not empty: nhg",
+		in: &Ops{
+			NHG: []*spb.AFTOperation{{}},
+		},
+		want: false,
+	}, {
+		desc: "not empty: nh",
+		in: &Ops{
+			NH: []*spb.AFTOperation{{}},
+		},
+		want: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := tt.in.IsEmpty(); got != tt.want {
+				t.Fatalf("(%v).IsEmpty(): did not get expected result, got: %v, want: %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/rib/rib.go
+++ b/rib/rib.go
@@ -354,6 +354,11 @@ type OpResult struct {
 	Error string
 }
 
+// String returns the OpResult as a human readable string.
+func (o *OpResult) String() string {
+	return fmt.Sprintf("ID: %d, Type: %s, Error: %v")
+}
+
 // AddEntry adds the entry described in op to the network instance with name ni. It returns
 // two slices of OpResults:
 //   - the first ("oks") describes the set of entries that were installed successfully based on

--- a/rib/rib.go
+++ b/rib/rib.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openconfig/ygot/ytypes"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
@@ -356,7 +357,7 @@ type OpResult struct {
 
 // String returns the OpResult as a human readable string.
 func (o *OpResult) String() string {
-	return fmt.Sprintf("ID: %d, Type: %s, Error: %v")
+	return fmt.Sprintf("ID: %d, Type: %s, Error: %v", o.ID, prototext.Format(o.Op), o.Error)
 }
 
 // AddEntry adds the entry described in op to the network instance with name ni. It returns


### PR DESCRIPTION
```
* (M) rib/reconciler/reconcile(_test)?.go
   - add an `IsEmpty` method for both `Ops` and `ReconcileOps` to
     determine whether they include any transactions.
```
