### PR TITLE
Add a `String` method to `OpResult`.

### DIFF
--- a/rib/rib.go
+++ b/rib/rib.go
@@ -354,6 +354,11 @@ type OpResult struct {
 	Error string
 }
 
+// String returns the OpResult as a human readable string.
+func (o *OpResult) String() string {
+	return fmt.Sprintf("ID: %d, Type: %s, Error: %v")
+}
+
 // AddEntry adds the entry described in op to the network instance with name ni. It returns
 // two slices of OpResults:
 //   - the first ("oks") describes the set of entries that were installed successfully based on

--- a/rib/rib.go
+++ b/rib/rib.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openconfig/ygot/ytypes"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
@@ -356,7 +357,7 @@ type OpResult struct {
 
 // String returns the OpResult as a human readable string.
 func (o *OpResult) String() string {
-	return fmt.Sprintf("ID: %d, Type: %s, Error: %v")
+	return fmt.Sprintf("ID: %d, Type: %s, Error: %v", o.ID, prototext.Format(o.Op), o.Error)
 }
 
 // AddEntry adds the entry described in op to the network instance with name ni. It returns


### PR DESCRIPTION
```
* (M) rib/rib.go
   - Add a `String` helper method to `OpResult` to improve human
     readability.
```
