### PR TITLE
Add support for `Flush` for IPv6, and server support.

### DIFF
--- a/client/gribiclient.go
+++ b/client/gribiclient.go
@@ -702,6 +702,8 @@ type OpDetailsResults struct {
 	NextHopGroupID uint64
 	// IPv4Prefix is the IPv4 prefix modified by the operation.
 	IPv4Prefix string
+	// IPv6Prefix is the IPv6 prefix modified by the operation.
+	IPv6Prefix string
 	// MPLSLabel is the MPLS label that was modified by the operation.
 	MPLSLabel uint64
 }
@@ -720,6 +722,8 @@ func (o *OpDetailsResults) String() string {
 		buf.WriteString(fmt.Sprintf("NHG ID: %d", o.NextHopGroupID))
 	case o.IPv4Prefix != "":
 		buf.WriteString(fmt.Sprintf("IPv4: %s", o.IPv4Prefix))
+	case o.IPv6Prefix != "":
+		buf.WriteString(fmt.Sprintf("IPv6: %s", o.IPv6Prefix))
 	case o.MPLSLabel != 0:
 		buf.WriteString(fmt.Sprintf("MPLS: %d", o.MPLSLabel))
 	}
@@ -949,6 +953,8 @@ func (c *Client) clearPendingOp(op *spb.AFTResult) (*OpResult, error) {
 	switch opEntry := v.Op.Entry.(type) {
 	case *spb.AFTOperation_Ipv4:
 		det.IPv4Prefix = opEntry.Ipv4.GetPrefix()
+	case *spb.AFTOperation_Ipv6:
+		det.IPv6Prefix = opEntry.Ipv6.GetPrefix()
 	case *spb.AFTOperation_Mpls:
 		det.MPLSLabel = opEntry.Mpls.GetLabelUint64()
 	case *spb.AFTOperation_NextHopGroup:

--- a/client/gribiclient_test.go
+++ b/client/gribiclient_test.go
@@ -1039,6 +1039,66 @@ func TestGet(t *testing.T) {
 			}},
 		},
 	}, {
+		desc: "single IPv6 entry in Server - specific NI",
+		inOperations: []*spb.AFTOperation{{
+			NetworkInstance: server.DefaultNetworkInstanceName,
+			Entry: &spb.AFTOperation_Ipv6{
+				Ipv6: &aftpb.Afts_Ipv6EntryKey{
+					Prefix:    "2001:db8::/32",
+					Ipv6Entry: &aftpb.Afts_Ipv6Entry{},
+				},
+			},
+		}},
+		inGetRequest: &spb.GetRequest{
+			NetworkInstance: &spb.GetRequest_Name{
+				Name: server.DefaultNetworkInstanceName,
+			},
+			Aft: spb.AFTType_ALL,
+		},
+		wantResponse: &spb.GetResponse{
+			Entry: []*spb.AFTEntry{{
+				NetworkInstance: server.DefaultNetworkInstanceName,
+				Entry: &spb.AFTEntry_Ipv6{
+					Ipv6: &aftpb.Afts_Ipv6EntryKey{
+						Prefix:    "2001:db8::/32",
+						Ipv6Entry: &aftpb.Afts_Ipv6Entry{},
+					},
+				},
+			}},
+		},
+	}, {
+		desc: "single MPLS entry in Server - specific NI",
+		inOperations: []*spb.AFTOperation{{
+			NetworkInstance: server.DefaultNetworkInstanceName,
+			Entry: &spb.AFTOperation_Mpls{
+				Mpls: &aftpb.Afts_LabelEntryKey{
+					Label: &aftpb.Afts_LabelEntryKey_LabelUint64{
+						LabelUint64: 42,
+					},
+					LabelEntry: &aftpb.Afts_LabelEntry{},
+				},
+			},
+		}},
+		inGetRequest: &spb.GetRequest{
+			NetworkInstance: &spb.GetRequest_Name{
+				Name: server.DefaultNetworkInstanceName,
+			},
+			Aft: spb.AFTType_ALL,
+		},
+		wantResponse: &spb.GetResponse{
+			Entry: []*spb.AFTEntry{{
+				NetworkInstance: server.DefaultNetworkInstanceName,
+				Entry: &spb.AFTEntry_Mpls{
+					Mpls: &aftpb.Afts_LabelEntryKey{
+						Label: &aftpb.Afts_LabelEntryKey_LabelUint64{
+							LabelUint64: 42,
+						},
+						LabelEntry: &aftpb.Afts_LabelEntry{},
+					},
+				},
+			}},
+		},
+	}, {
 		desc: "multiple entries - single NI",
 		inOperations: []*spb.AFTOperation{{
 			NetworkInstance: server.DefaultNetworkInstanceName,

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -311,6 +311,8 @@ const (
 	NextHopGroup
 	// NextHop references the NextHop AFT.
 	NextHop
+	// IPv6 references the IPv6Entry AFT.
+	IPv6
 )
 
 // aftMap provides mapping between the AFT enumerated type within the fluent
@@ -320,6 +322,7 @@ var aftMap = map[AFT]spb.AFTType{
 	IPv4:         spb.AFTType_IPV4,
 	NextHopGroup: spb.AFTType_NEXTHOP_GROUP,
 	NextHop:      spb.AFTType_NEXTHOP,
+	IPv6:         spb.AFTType_IPV6,
 }
 
 // WithAFT specifies the AFT for which the Get request is made. The AllAFTs
@@ -599,6 +602,94 @@ func (i *ipv4Entry) EntryProto() (*spb.AFTEntry, error) {
 		NetworkInstance: i.ni,
 		Entry: &spb.AFTEntry_Ipv4{
 			Ipv4: proto.Clone(i.pb).(*aftpb.Afts_Ipv4EntryKey),
+		},
+	}, nil
+}
+
+// ipv6Entry is the internal representation of a gRIBI IPv6Entry.
+type ipv6Entry struct {
+	// pb is the gRIBI IPv4Entry that is being composed.
+	pb *aftpb.Afts_Ipv6EntryKey
+	// ni is the network instance to which the IPv4Entry is applied.
+	ni string
+	// electionID is an explicit election ID to be used for an
+	// operation using the entry.
+	electionID *spb.Uint128
+}
+
+// IPv6Entry returns a new gRIBI IPv6Entry builder.
+func IPv6Entry() *ipv6Entry {
+	return &ipv6Entry{
+		pb: &aftpb.Afts_Ipv6EntryKey{
+			Ipv6Entry: &aftpb.Afts_Ipv6Entry{},
+		},
+	}
+}
+
+// WithPrefix sets the prefix of the IPv6Entry to the specified value, which
+// must be a valid IPv6 prefix in the form prefix/mask.
+func (i *ipv6Entry) WithPrefix(p string) *ipv6Entry {
+	i.pb.Prefix = p
+	return i
+}
+
+// WithNetworkInstance specifies the network instance to which the IPv6Entry
+// is being applied.
+func (i *ipv6Entry) WithNetworkInstance(n string) *ipv6Entry {
+	i.ni = n
+	return i
+}
+
+// WithNextHopGroup specifies the next-hop group that the IPv6Entry points to.
+func (i *ipv6Entry) WithNextHopGroup(u uint64) *ipv6Entry {
+	i.pb.Ipv6Entry.NextHopGroup = &wpb.UintValue{Value: u}
+	return i
+}
+
+// WithNextHopGroupNetworkInstance specifies the network-instance within which
+// the next-hop-group for the IPv6 entry should be resolved.
+func (i *ipv6Entry) WithNextHopGroupNetworkInstance(n string) *ipv6Entry {
+	i.pb.Ipv6Entry.NextHopGroupNetworkInstance = &wpb.StringValue{Value: n}
+	return i
+}
+
+// WithMetadata specifies a byte slice that is stored as metadata alongside
+// the IPV6 entry on the gRIBI server.
+func (i *ipv6Entry) WithMetadata(b []byte) *ipv6Entry {
+	i.pb.Ipv6Entry.EntryMetadata = &wpb.BytesValue{Value: b}
+	return i
+}
+
+// WithElectionID specifies an explicit election ID to be used for the Entry.
+// The election ID is made up of the concatenation of the low and high uint64
+// values provided.
+func (i *ipv6Entry) WithElectionID(low, high uint64) *ipv6Entry {
+	i.electionID = &spb.Uint128{
+		Low:  low,
+		High: high,
+	}
+	return i
+}
+
+// OpProto implements the gRIBIEntry interface, returning a gRIBI AFTOperation. ID
+// is explicitly not populated such that they can be populated by
+// the function (e.g., AddEntry) to which they are an argument.
+func (i *ipv6Entry) OpProto() (*spb.AFTOperation, error) {
+	return &spb.AFTOperation{
+		NetworkInstance: i.ni,
+		Entry: &spb.AFTOperation_Ipv6{
+			Ipv6: proto.Clone(i.pb).(*aftpb.Afts_Ipv6EntryKey),
+		},
+		ElectionId: i.electionID,
+	}, nil
+}
+
+// EntryProto implements the GRIBIEntry interface, building a gRIBI AFTEntry.
+func (i *ipv6Entry) EntryProto() (*spb.AFTEntry, error) {
+	return &spb.AFTEntry{
+		NetworkInstance: i.ni,
+		Entry: &spb.AFTEntry_Ipv6{
+			Ipv6: proto.Clone(i.pb).(*aftpb.Afts_Ipv6EntryKey),
 		},
 	}, nil
 }

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -1158,6 +1158,17 @@ func (o *opResult) WithIPv4Operation(p string) *opResult {
 	return o
 }
 
+// WithIPv6Operation indicates that the result corresponds to
+// an operation impacting the IPv6 prefix p which is of the form
+// prefix/mask.
+func (o *opResult) WithIPv6Operation(p string) *opResult {
+	if o.r.Details == nil {
+		o.r.Details = &client.OpDetailsResults{}
+	}
+	o.r.Details.IPv6Prefix = p
+	return o
+}
+
 // WithNextHopGroupOperation indicates that the result correspodns to
 // an operation impacting the next-hop-group with index i.
 func (o *opResult) WithNextHopGroupOperation(i uint64) *opResult {

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -385,13 +385,14 @@ func TestEntry(t *testing.T) {
 		},
 	}, {
 		desc: "mpls entry",
-		in:   LabelEntry().WithNetworkInstance("DEFAULT").WithLabel(42).WithNextHopGroupNetworkInstance("DEFAULT").WithPoppedLabelStack(10, 20),
+		in:   LabelEntry().WithNetworkInstance("DEFAULT").WithLabel(42).WithNextHopGroup(1).WithNextHopGroupNetworkInstance("DEFAULT").WithPoppedLabelStack(10, 20),
 		wantOpProto: &spb.AFTOperation{
 			NetworkInstance: "DEFAULT",
 			Entry: &spb.AFTOperation_Mpls{
 				Mpls: &aftpb.Afts_LabelEntryKey{
 					Label: &aftpb.Afts_LabelEntryKey_LabelUint64{LabelUint64: 42},
 					LabelEntry: &aftpb.Afts_LabelEntry{
+						NextHopGroup:                &wpb.UintValue{Value: 1},
 						NextHopGroupNetworkInstance: &wpb.StringValue{Value: "DEFAULT"},
 						PoppedMplsLabelStack: []*aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{
 							{PoppedMplsLabelStackUint64: 10},
@@ -407,11 +408,41 @@ func TestEntry(t *testing.T) {
 				Mpls: &aftpb.Afts_LabelEntryKey{
 					Label: &aftpb.Afts_LabelEntryKey_LabelUint64{LabelUint64: 42},
 					LabelEntry: &aftpb.Afts_LabelEntry{
+						NextHopGroup:                &wpb.UintValue{Value: 1},
 						NextHopGroupNetworkInstance: &wpb.StringValue{Value: "DEFAULT"},
 						PoppedMplsLabelStack: []*aftpb.Afts_LabelEntry_PoppedMplsLabelStackUnion{
 							{PoppedMplsLabelStackUint64: 10},
 							{PoppedMplsLabelStackUint64: 20},
 						},
+					},
+				},
+			},
+		},
+	}, {
+		desc: "ipv6 entry",
+		in:   IPv6Entry().WithNetworkInstance("DEFAULT").WithPrefix("2001:db8::/42").WithNextHopGroup(1).WithNextHopGroupNetworkInstance("DEFAULT").WithMetadata([]byte{1, 2, 3, 4}),
+		wantOpProto: &spb.AFTOperation{
+			NetworkInstance: "DEFAULT",
+			Entry: &spb.AFTOperation_Ipv6{
+				Ipv6: &aftpb.Afts_Ipv6EntryKey{
+					Prefix: "2001:db8::/42",
+					Ipv6Entry: &aftpb.Afts_Ipv6Entry{
+						NextHopGroup:                &wpb.UintValue{Value: 1},
+						NextHopGroupNetworkInstance: &wpb.StringValue{Value: "DEFAULT"},
+						EntryMetadata:               &wpb.BytesValue{Value: []byte{1, 2, 3, 4}},
+					},
+				},
+			},
+		},
+		wantEntryProto: &spb.AFTEntry{
+			NetworkInstance: "DEFAULT",
+			Entry: &spb.AFTEntry_Ipv6{
+				Ipv6: &aftpb.Afts_Ipv6EntryKey{
+					Prefix: "2001:db8::/42",
+					Ipv6Entry: &aftpb.Afts_Ipv6Entry{
+						NextHopGroup:                &wpb.UintValue{Value: 1},
+						NextHopGroupNetworkInstance: &wpb.StringValue{Value: "DEFAULT"},
+						EntryMetadata:               &wpb.BytesValue{Value: []byte{1, 2, 3, 4}},
 					},
 				},
 			},
@@ -425,7 +456,7 @@ func TestEntry(t *testing.T) {
 				t.Fatalf("did not get expected error for op, got: %v, wantErr? %v", err, tt.wantOpErr)
 			}
 			if diff := cmp.Diff(gotop, tt.wantOpProto, protocmp.Transform()); diff != "" {
-				t.Fatalf("did not get expected proto, diff(-got,+want):\n%s", diff)
+				t.Fatalf("did not get expected Operation proto, diff(-got,+want):\n%s", diff)
 			}
 
 			gotent, err := tt.in.EntryProto()
@@ -433,7 +464,7 @@ func TestEntry(t *testing.T) {
 				t.Fatalf("did not get expected error for entry, got: %v, wantErr? %v", err, tt.wantEntryErr)
 			}
 			if diff := cmp.Diff(gotent, tt.wantEntryProto, protocmp.Transform()); diff != "" {
-				t.Fatalf("did not get expexcted proto, diff(-got,+want)\n%s", diff)
+				t.Fatalf("did not get expected Entry proto, diff(-got,+want)\n%s", diff)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,14 @@ go 1.20
 
 require (
 	github.com/golang/glog v1.1.2
-	github.com/google/go-cmp v0.5.9
+	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.3.0
 	github.com/openconfig/gnmi v0.10.0
-	github.com/openconfig/goyang v1.4.1
+	github.com/openconfig/goyang v1.4.3
 	github.com/openconfig/gribi v1.0.0
 	github.com/openconfig/lemming v0.3.2-0.20230914210403-c6484d12af0a
 	github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07
-	github.com/openconfig/ygot v0.29.12
+	github.com/openconfig/ygot v0.29.14-0.20231104225320-3ff6621e6f61
 	go.uber.org/atomic v1.10.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230822172742-b8732ec3820d
 	google.golang.org/grpc v1.58.0-dev

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,6 @@ github.com/openconfig/ygnmi v0.8.7/go.mod h1:7up6qc9l9G4+Cfo37gzO0D7+2g4yqyW+xzh
 github.com/openconfig/ygot v0.6.0/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQSmIhqwAs=
 github.com/openconfig/ygot v0.10.4/go.mod h1:oCQNdXnv7dWc8scTDgoFkauv1wwplJn5HspHcjlxSAQ=
 github.com/openconfig/ygot v0.13.2/go.mod h1:kJN0yCXIH07dOXvNBEFm3XxXdnDD5NI6K99tnD5x49c=
-github.com/openconfig/ygot v0.29.14-0.20231104170448-947750b6679c h1:b0ISmmh+7rlR4vjy5vHlUYZiGU51L5waeW5oYcalstw=
-github.com/openconfig/ygot v0.29.14-0.20231104170448-947750b6679c/go.mod h1:g0o3F+0ap1IExvFctDDU+PwSd20EXGpDDeAGo+vayqw=
 github.com/openconfig/ygot v0.29.14-0.20231104225320-3ff6621e6f61 h1:DocMzb9Qa8uD5EWDZiBCQdaU2PJQG/N1ZlAVVdy6XUs=
 github.com/openconfig/ygot v0.29.14-0.20231104225320-3ff6621e6f61/go.mod h1:g0o3F+0ap1IExvFctDDU+PwSd20EXGpDDeAGo+vayqw=
 github.com/p4lang/p4runtime v1.4.0-rc.5.0.20220728214547-13f0d02a521e h1:AfZKoikDXbZ7zWvO/lvCRzLo7i6lM+gNleYVMxPiWyQ=

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -193,8 +193,8 @@ github.com/openconfig/gocloser v0.0.0-20220310182203-c6c950ed3b0b/go.mod h1:uhC/
 github.com/openconfig/goyang v0.0.0-20200115183954-d0a48929f0ea/go.mod h1:dhXaV0JgHJzdrHi2l+w0fZrwArtXL7jEFoiqLEdmkvU=
 github.com/openconfig/goyang v0.2.2/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+RrNkXRd3W8=
 github.com/openconfig/goyang v0.2.9/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+RrNkXRd3W8=
-github.com/openconfig/goyang v1.4.1 h1:OmkovLj01iOskzviwnoXkWWY0fwfhPVGTAKKCMSbgeE=
-github.com/openconfig/goyang v1.4.1/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+RrNkXRd3W8=
+github.com/openconfig/goyang v1.4.3 h1:9sr+l1vRbON0cMZxmogMhI8JiNqIf1uJoN8o4OdNqxI=
+github.com/openconfig/goyang v1.4.3/go.mod h1:vX61x01Q46AzbZUzG617vWqh/cB+aisc+RrNkXRd3W8=
 github.com/openconfig/gribi v0.1.1-0.20210423184541-ce37eb4ba92f/go.mod h1:OoH46A2kV42cIXGyviYmAlGmn6cHjGduyC2+I9d/iVs=
 github.com/openconfig/gribi v1.0.0 h1:xMwEg0mBD+21mOxuFOw0d9dBKuIPwJEhMUUeUulZdLg=
 github.com/openconfig/gribi v1.0.0/go.mod h1:VFqGH2ZPFIfnKTimP4/AQB4OK0eySW5muJNFxXAwP6k=
@@ -208,8 +208,10 @@ github.com/openconfig/ygnmi v0.8.7/go.mod h1:7up6qc9l9G4+Cfo37gzO0D7+2g4yqyW+xzh
 github.com/openconfig/ygot v0.6.0/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQSmIhqwAs=
 github.com/openconfig/ygot v0.10.4/go.mod h1:oCQNdXnv7dWc8scTDgoFkauv1wwplJn5HspHcjlxSAQ=
 github.com/openconfig/ygot v0.13.2/go.mod h1:kJN0yCXIH07dOXvNBEFm3XxXdnDD5NI6K99tnD5x49c=
-github.com/openconfig/ygot v0.29.12 h1:LjjeaRGdGEOWhldSm0fr8YarPlTgy2fCAaCvY+3pO3Y=
-github.com/openconfig/ygot v0.29.12/go.mod h1:RNnn1ytQ8GZV5LPts36l0cyoRjsYYpruiruJEvmU2sg=
+github.com/openconfig/ygot v0.29.14-0.20231104170448-947750b6679c h1:b0ISmmh+7rlR4vjy5vHlUYZiGU51L5waeW5oYcalstw=
+github.com/openconfig/ygot v0.29.14-0.20231104170448-947750b6679c/go.mod h1:g0o3F+0ap1IExvFctDDU+PwSd20EXGpDDeAGo+vayqw=
+github.com/openconfig/ygot v0.29.14-0.20231104225320-3ff6621e6f61 h1:DocMzb9Qa8uD5EWDZiBCQdaU2PJQG/N1ZlAVVdy6XUs=
+github.com/openconfig/ygot v0.29.14-0.20231104225320-3ff6621e6f61/go.mod h1:g0o3F+0ap1IExvFctDDU+PwSd20EXGpDDeAGo+vayqw=
 github.com/p4lang/p4runtime v1.4.0-rc.5.0.20220728214547-13f0d02a521e h1:AfZKoikDXbZ7zWvO/lvCRzLo7i6lM+gNleYVMxPiWyQ=
 github.com/p4lang/p4runtime v1.4.0-rc.5.0.20220728214547-13f0d02a521e/go.mod h1:m9laObIMXM9N1ElGXijc66/MSM5eheZJLRLxg/TG+fU=
 github.com/pborman/getopt v0.0.0-20190409184431-ee0cd42419d3/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=

--- a/rib/rib_test.go
+++ b/rib/rib_test.go
@@ -5242,6 +5242,43 @@ func TestFlush(t *testing.T) {
 
 			return r
 		}(),
+	}, {
+		desc: "ipv6",
+		inRIB: func() *RIBHolder {
+			r := NewRIBHolder("DEFAULT")
+			r.checkFn = nil
+
+			_, _, err := r.AddIPv6(&aftpb.Afts_Ipv6EntryKey{
+				Prefix: "2001:db8::/32",
+				Ipv6Entry: &aftpb.Afts_Ipv6Entry{
+					NextHopGroup: &wpb.UintValue{Value: 1},
+				},
+			}, false)
+			if err != nil {
+				t.Fatalf("cannot add ipv6 entry, %v", err)
+			}
+
+			return r
+		}(),
+	}, {
+		desc: "mpls",
+		inRIB: func() *RIBHolder {
+			r := NewRIBHolder("DEFAULT")
+			r.checkFn = nil
+
+			_, _, err := r.AddMPLS(&aftpb.Afts_LabelEntryKey{
+				Label: &aftpb.Afts_LabelEntryKey_LabelUint64{
+					LabelUint64: 42,
+				},
+				LabelEntry: &aftpb.Afts_LabelEntry{
+					NextHopGroup: &wpb.UintValue{Value: 1},
+				},
+			}, false)
+			if err != nil {
+				t.Fatalf("cannot add ipv6 entry, %v", err)
+			}
+			return r
+		}(),
 	}}
 
 	for _, tt := range tests {
@@ -5254,6 +5291,14 @@ func TestFlush(t *testing.T) {
 
 		if l := len(tt.inRIB.r.Afts.Ipv4Entry); l != 0 {
 			t.Fatalf("did not remove all IPv4 entries, got: %d, want: 0", l)
+		}
+
+		if l := len(tt.inRIB.r.Afts.Ipv6Entry); l != 0 {
+			t.Fatalf("did not remove all IPv6 entries, got: %d, want: 0", l)
+		}
+
+		if l := len(tt.inRIB.r.Afts.LabelEntry); l != 0 {
+			t.Fatalf("did not remove all MPLS entries, got: %d, want: 0", l)
 		}
 
 		if l := len(tt.inRIB.r.Afts.NextHopGroup); l != 0 {

--- a/server/server.go
+++ b/server/server.go
@@ -1039,10 +1039,10 @@ func (s *Server) doGet(req *spb.GetRequest, msgCh chan *spb.GetResponse, doneCh,
 
 	filter := map[spb.AFTType]bool{}
 	switch v := req.Aft; v {
-	case spb.AFTType_ALL, spb.AFTType_IPV4, spb.AFTType_NEXTHOP, spb.AFTType_NEXTHOP_GROUP:
+	case spb.AFTType_ALL, spb.AFTType_IPV4, spb.AFTType_NEXTHOP, spb.AFTType_NEXTHOP_GROUP, spb.AFTType_MPLS, spb.AFTType_IPV6:
 		filter[v] = true
 	default:
-		errCh <- status.Errorf(codes.Unimplemented, "AFTs other than IPv4, IPv6, NHG and NH are unimplemented, requested: %s", v)
+		errCh <- status.Errorf(codes.Unimplemented, "AFTs other than IPv4, MPLS, IPv6, NHG and NH are unimplemented, requested: %s", v)
 	}
 
 	for _, ni := range netInstances {


### PR DESCRIPTION
```
 * (M) rib/rib.go
  - Add support for `Flush` calls to remove IPv6 entries.
 * (M) rib/rib_test.go
  - Ensure that test coverage exists for both MPLS and IPv6 for Flush.
```

```
 * (M) go.{mod,sum}
  - Upgrade to non-release version of ygot to fix bug with parsing
    of pushed label stacks.
 * (M) server/server(_test)?.go
  - Add support and testing for IPv6 into server.
```