### PR TITLE
Fix implementation of Flush.

### DIFF
--- a/cmd/stubrtr/main.go
+++ b/cmd/stubrtr/main.go
@@ -1,0 +1,93 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Binary stubrtr is a basic gRIBI stub server. Unlike the more fully featured
+// device it does not have other dependencies outside of gRIBIgo, making it
+// more suitable for direct gRIBI testing or debugging.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"strings"
+
+	log "github.com/golang/glog"
+	"github.com/openconfig/gribigo/server"
+	"github.com/openconfig/gribigo/testcommon"
+	"google.golang.org/grpc"
+
+	"net/http"
+	_ "net/http/pprof"
+
+	spb "github.com/openconfig/gribi/v1/proto/service"
+)
+
+var (
+	certFile = flag.String("cert", "", "cert is the path to the server TLS certificate file")
+	keyFile  = flag.String("key", "", "key is the path to the server TLS key file")
+	addr     = flag.String("addr", ":9340", "gribi listen address")
+	vrfs     = flag.String("vrfs", "NON-DEFAULT-VRF", "additional VRFs to initialise on the server")
+)
+
+func main() {
+	flag.Parse()
+
+	if *certFile == "" || *keyFile == "" {
+		log.Exitf("must specify a TLS certificate and key file")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	creds, err := testcommon.TLSCredsFromFile(*certFile, *keyFile)
+	if err != nil {
+		log.Exitf("cannot initialise TLS, got: %v", err)
+	}
+
+	opts := []server.ServerOpt{}
+	vrfList := strings.Split(*vrfs, ",")
+	if len(vrfList) != 0 {
+		opts = append(opts, server.WithVRFs(vrfList))
+	}
+
+	stop, err := startgRIBI(ctx, *addr, creds, opts...)
+	if err != nil {
+		log.Exitf("cannot start gRIBI server, %v", err)
+	}
+	defer stop()
+
+	go func() {
+		log.Infof("%v", http.ListenAndServe("localhost:6060", nil))
+	}()
+	<-ctx.Done()
+}
+
+func startgRIBI(ctx context.Context, addr string, creds *testcommon.TLSCred, opt ...server.ServerOpt) (func(), error) {
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gRPC server for gRIBI, %v", err)
+	}
+
+	s := grpc.NewServer(grpc.Creds(creds.C))
+	ts, err := server.New(opt...)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create gRIBI server, %v", err)
+	}
+	spb.RegisterGRIBIServer(s, ts)
+
+	go s.Serve(l)
+	log.Infof("listening on %s", l.Addr().String())
+	return s.GracefulStop, nil
+}

--- a/rib/rib_test.go
+++ b/rib/rib_test.go
@@ -5091,14 +5091,15 @@ func mustSharedNHRIB(nhNI string) *RIB {
 func TestFlush(t *testing.T) {
 	tests := []struct {
 		desc             string
-		inRIB            *RIBHolder
+		inRIB            *RIB
+		wantEmptyNIs     []string
 		wantErrSubstring string
 	}{{
 		desc: "nh only",
-		inRIB: func() *RIBHolder {
-			r := NewRIBHolder("DEFAULT")
-
-			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
+		inRIB: func() *RIB {
+			dn := "DEFAULT"
+			r := New(dn)
+			_, _, err := r.niRIB[dn].AddNextHop(&aftpb.Afts_NextHopKey{
 				Index: 1,
 				NextHop: &aftpb.Afts_NextHop{
 					IpAddress: &wpb.StringValue{Value: "1.2.3.4"},
@@ -5110,10 +5111,13 @@ func TestFlush(t *testing.T) {
 
 			return r
 		}(),
+		wantEmptyNIs: []string{"DEFAULT"},
 	}, {
 		desc: "nhg + nh",
-		inRIB: func() *RIBHolder {
-			r := NewRIBHolder("DEFAULT")
+		inRIB: func() *RIB {
+			dn := "DEFAULT"
+			rr := New(dn)
+			r := rr.niRIB[dn]
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
 				Index: 1,
@@ -5140,12 +5144,15 @@ func TestFlush(t *testing.T) {
 				t.Fatalf("cannot add next-hop-group, %v", err)
 			}
 
-			return r
+			return rr
 		}(),
+		wantEmptyNIs: []string{"DEFAULT"},
 	}, {
 		desc: "nhg with backup + nh",
-		inRIB: func() *RIBHolder {
-			r := NewRIBHolder("DEFAULT")
+		inRIB: func() *RIB {
+			dn := "DEFAULT"
+			rr := New(dn)
+			r := rr.niRIB[dn]
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
 				Index: 1,
@@ -5188,12 +5195,15 @@ func TestFlush(t *testing.T) {
 				t.Fatalf("cannot add next-hop-group, %v", err)
 			}
 
-			return r
+			return rr
 		}(),
+		wantEmptyNIs: []string{"DEFAULT"},
 	}, {
 		desc: "circular reference to NHG",
-		inRIB: func() *RIBHolder {
-			r := NewRIBHolder("DEFAULT")
+		inRIB: func() *RIB {
+			dn := "DEFAULT"
+			rr := New(dn)
+			r := rr.niRIB[dn]
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
 				Index: 1,
@@ -5237,12 +5247,15 @@ func TestFlush(t *testing.T) {
 				t.Fatalf("cannot add next-hop-group, %v", err)
 			}
 
-			return r
+			return rr
 		}(),
+		wantEmptyNIs: []string{"DEFAULT"},
 	}, {
 		desc: "ipv4 + nhg + nh",
-		inRIB: func() *RIBHolder {
-			r := NewRIBHolder("DEFAULT")
+		inRIB: func() *RIB {
+			dn := "DEFAULT"
+			rr := New(dn)
+			r := rr.niRIB[dn]
 
 			_, _, err := r.AddNextHop(&aftpb.Afts_NextHopKey{
 				Index: 1,
@@ -5279,12 +5292,16 @@ func TestFlush(t *testing.T) {
 				t.Fatalf("cannot add ipv4 entry, %v", err)
 			}
 
-			return r
+			return rr
 		}(),
+		wantEmptyNIs: []string{"DEFAULT"},
 	}, {
 		desc: "ipv6",
-		inRIB: func() *RIBHolder {
-			r := NewRIBHolder("DEFAULT")
+		inRIB: func() *RIB {
+			dn := "DEFAULT"
+			rr := New(dn)
+			r := rr.niRIB[dn]
+
 			r.checkFn = nil
 
 			_, _, err := r.AddIPv6(&aftpb.Afts_Ipv6EntryKey{
@@ -5297,12 +5314,16 @@ func TestFlush(t *testing.T) {
 				t.Fatalf("cannot add ipv6 entry, %v", err)
 			}
 
-			return r
+			return rr
 		}(),
+		wantEmptyNIs: []string{"DEFAULT"},
 	}, {
 		desc: "mpls",
-		inRIB: func() *RIBHolder {
-			r := NewRIBHolder("DEFAULT")
+		inRIB: func() *RIB {
+			dn := "DEFAULT"
+			rr := New(dn)
+			r := rr.niRIB[dn]
+
 			r.checkFn = nil
 
 			_, _, err := r.AddMPLS(&aftpb.Afts_LabelEntryKey{
@@ -5314,38 +5335,104 @@ func TestFlush(t *testing.T) {
 				},
 			}, false)
 			if err != nil {
-				t.Fatalf("cannot add ipv6 entry, %v", err)
+				t.Fatalf("cannot add MPLS entry, %v", err)
 			}
-			return r
+			return rr
 		}(),
+		wantEmptyNIs: []string{"DEFAULT"},
+	}, {
+		desc: "flush with references across VRFs",
+		inRIB: func() *RIB {
+			dn := "DEFAULT"
+			nd := "NON-DEFAULT"
+			rr := New(dn)
+			rr.AddNetworkInstance(nd)
+
+			defRIB := rr.niRIB[dn]
+			nonDefRIB := rr.niRIB[nd]
+
+			if _, _, err := defRIB.AddNextHop(&aftpb.Afts_NextHopKey{
+				Index: 1,
+				NextHop: &aftpb.Afts_NextHop{
+					IpAddress: &wpb.StringValue{Value: "192.0.2.1"},
+				},
+			}, false); err != nil {
+				t.Fatalf("cannot add NH, %v", err)
+			}
+
+			if _, _, err := defRIB.AddNextHopGroup(&aftpb.Afts_NextHopGroupKey{
+				Id: 1,
+				NextHopGroup: &aftpb.Afts_NextHopGroup{
+					NextHop: []*aftpb.Afts_NextHopGroup_NextHopKey{{
+						Index: 1,
+						NextHop: &aftpb.Afts_NextHopGroup_NextHop{
+							Weight: &wpb.UintValue{Value: 1},
+						},
+					}},
+				},
+			}, false); err != nil {
+				t.Fatalf("cannot add NHG, %v", err)
+			}
+
+			if _, _, err := nonDefRIB.AddIPv4(&aftpb.Afts_Ipv4EntryKey{
+				Prefix: "192.0.2.0/32",
+				Ipv4Entry: &aftpb.Afts_Ipv4Entry{
+					NextHopGroup:                &wpb.UintValue{Value: 1},
+					NextHopGroupNetworkInstance: &wpb.StringValue{Value: dn},
+				},
+			}, false); err != nil {
+				t.Fatalf("cannot add IPv4 entry to non-default VRF, %v", err)
+			}
+			return rr
+		}(),
+		wantEmptyNIs: []string{"NON-DEFAULT", "DEFAULT"},
 	}}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			got := tt.inRIB.Flush()
+			got := tt.inRIB.Flush(tt.wantEmptyNIs)
 			if diff := errdiff.Substring(got, tt.wantErrSubstring); diff != "" {
 				t.Fatalf("did not get expected error when flushing RIB, %s", diff)
 			}
 		})
 
-		if l := len(tt.inRIB.r.Afts.Ipv4Entry); l != 0 {
-			t.Fatalf("did not remove all IPv4 entries, got: %d, want: 0", l)
-		}
+		for _, niName := range tt.wantEmptyNIs {
+			niRIB, ok := tt.inRIB.NetworkInstanceRIB(niName)
+			if !ok {
+				t.Fatalf("cannot get network instance RIB for %s", niName)
+			}
 
-		if l := len(tt.inRIB.r.Afts.Ipv6Entry); l != 0 {
-			t.Fatalf("did not remove all IPv6 entries, got: %d, want: 0", l)
-		}
+			if l := len(niRIB.r.Afts.Ipv4Entry); l != 0 {
+				t.Fatalf("NI: %s, did not remove all IPv4 entries, got: %d, want: 0", niName, l)
+			}
 
-		if l := len(tt.inRIB.r.Afts.LabelEntry); l != 0 {
-			t.Fatalf("did not remove all MPLS entries, got: %d, want: 0", l)
-		}
+			if l := len(niRIB.r.Afts.Ipv6Entry); l != 0 {
+				t.Fatalf("NI: %s, did not remove all IPv6 entries, got: %d, want: 0", niName, l)
+			}
 
-		if l := len(tt.inRIB.r.Afts.NextHopGroup); l != 0 {
-			t.Fatalf("did not remove all IPv4 entries, got: %d, want: 0", l)
-		}
+			if l := len(niRIB.r.Afts.LabelEntry); l != 0 {
+				t.Fatalf("NI: %s, did not remove all MPLS entries, got: %d, want: 0", niName, l)
+			}
 
-		if l := len(tt.inRIB.r.Afts.NextHop); l != 0 {
-			t.Fatalf("did not remove all IPv4 entries, got: %d, want: 0", l)
+			if l := len(niRIB.r.Afts.NextHopGroup); l != 0 {
+				t.Fatalf("NI: %s, did not remove all IPv4 entries, got: %d, want: 0", niName, l)
+			}
+
+			if l := len(niRIB.r.Afts.NextHop); l != 0 {
+				t.Fatalf("NI: %s, did not remove all IPv4 entries, got: %d, want: 0", niName, l)
+			}
+
+			for nhID, gotCount := range niRIB.refCounts.NextHop {
+				if gotCount != 0 {
+					t.Errorf("invalid non-zero refcount for NH ID %d, got: %d, want: 0", nhID, gotCount)
+				}
+			}
+
+			for nhgID, gotCount := range niRIB.refCounts.NextHopGroup {
+				if gotCount != 0 {
+					t.Errorf("invalid non-zero refcount for NHG ID %d, got: %d, want: 0", nhgID, gotCount)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
```
 * (M) rib/rib(_test).go
  - Replace `Flush` implementation to be at the RIB level to allow
    for cross-NI references.
```

Ensures that when the RIB is flushed then reference counts can be updated accordingly.
Adds additional refcount unit tests.
