### PR TITLE
Add support for loading IPv6 GetResponse contents into RIB.

### DIFF
--- a/rib/helpers.go
+++ b/rib/helpers.go
@@ -41,6 +41,8 @@ func FromGetResponses(defaultName string, responses []*spb.GetResponse, opt ...R
 				niAFTs[ni].Ipv4Entry = append(niAFTs[ni].Ipv4Entry, t.Ipv4)
 			case *spb.AFTEntry_Mpls:
 				niAFTs[ni].LabelEntry = append(niAFTs[ni].LabelEntry, t.Mpls)
+			case *spb.AFTEntry_Ipv6:
+				niAFTs[ni].Ipv6Entry = append(niAFTs[ni].Ipv6Entry, t.Ipv6)
 			case *spb.AFTEntry_NextHopGroup:
 				niAFTs[ni].NextHopGroup = append(niAFTs[ni].NextHopGroup, t.NextHopGroup)
 			case *spb.AFTEntry_NextHop:

--- a/rib/helpers_test.go
+++ b/rib/helpers_test.go
@@ -76,6 +76,46 @@ func TestFromGetResponses(t *testing.T) {
 			},
 		},
 	}, {
+		desc: "single ipv6 entry",
+		inResponses: []*spb.GetResponse{{
+			Entry: []*spb.AFTEntry{{
+				NetworkInstance: "VRF-1",
+				Entry: &spb.AFTEntry_Ipv6{
+					Ipv6: &aftpb.Afts_Ipv6EntryKey{
+						Prefix: "2001:db8::/32",
+						Ipv6Entry: &aftpb.Afts_Ipv6Entry{
+							NextHopGroup: &wpb.UintValue{Value: 42},
+						},
+					},
+				},
+			}},
+		}},
+		inDefaultName: "DEFAULT",
+		wantRIB: &RIB{
+			defaultName: defaultName,
+			niRIB: map[string]*RIBHolder{
+				"DEFAULT": {
+					name: "DEFAULT",
+					r: &aft.RIB{
+						Afts: &aft.Afts{},
+					},
+				},
+				"VRF-1": {
+					name: "VRF-1",
+					r: &aft.RIB{
+						Afts: &aft.Afts{
+							Ipv6Entry: map[string]*aft.Afts_Ipv6Entry{
+								"2001:db8::/32": {
+									Prefix:       ygot.String("2001:db8::/32"),
+									NextHopGroup: ygot.Uint64(42),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
 		desc: "next-hop group entry",
 		inResponses: []*spb.GetResponse{{
 			Entry: []*spb.AFTEntry{{


### PR DESCRIPTION
```
* (M) rib/helpers(_test)?.go
   - Add support for loading IPv6 AFT entries into a RIB from
     a gRIBI GetResponse set of messages. Previously this was
     unsupported, but the addition of IPv6 into the gRIBIgo RIB
     means that this can now be supported.
```
