### PR TITLE
Revert "Don't populate an empty NextHop in AFTOperations"

### DIFF
--- a/compliance/compliance.go
+++ b/compliance/compliance.go
@@ -831,7 +831,7 @@ func AddIPv4EntryRandom(c *fluent.GRIBIClient, t testing.TB, _ ...TestOpt) {
 	defer flushServer(c, t)
 	ops := []func(){
 		func() {
-			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(1).WithIPAddress("192.0.2.3"))
+			c.Modify().AddEntry(t, fluent.NextHopEntry().WithNetworkInstance(defaultNetworkInstanceName).WithIndex(1))
 		},
 		func() {
 			c.Modify().AddEntry(t, fluent.NextHopGroupEntry().WithNetworkInstance(defaultNetworkInstanceName).WithID(42).AddNextHop(1, 1))

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -796,7 +796,9 @@ type nextHopEntry struct {
 // gRIBI.
 func NextHopEntry() *nextHopEntry {
 	return &nextHopEntry{
-		pb: &aftpb.Afts_NextHopKey{},
+		pb: &aftpb.Afts_NextHopKey{
+			NextHop: &aftpb.Afts_NextHop{},
+		},
 	}
 }
 
@@ -816,19 +818,12 @@ func (n *nextHopEntry) WithNetworkInstance(ni string) *nextHopEntry {
 // WithIPAddress specifies an IP address to be used for the next-hop. The IP
 // address is resolved within the network instance specified by WithNextHopNetworkInstance.
 func (n *nextHopEntry) WithIPAddress(addr string) *nextHopEntry {
-	if n.pb.NextHop == nil {
-		n.pb.NextHop = &aftpb.Afts_NextHop{}
-	}
 	n.pb.NextHop.IpAddress = &wpb.StringValue{Value: addr}
-
 	return n
 }
 
 // WithInterfaceRef specifies an interface to be used for the next-hop.
 func (n *nextHopEntry) WithInterfaceRef(name string) *nextHopEntry {
-	if n.pb.NextHop == nil {
-		n.pb.NextHop = &aftpb.Afts_NextHop{}
-	}
 	n.pb.NextHop.InterfaceRef = &aftpb.Afts_NextHop_InterfaceRef{
 		Interface: &wpb.StringValue{Value: name},
 	}
@@ -838,9 +833,6 @@ func (n *nextHopEntry) WithInterfaceRef(name string) *nextHopEntry {
 // WithSubinterfaceRef specifies both an interface and a specific
 // subinterface to be used for the next-hop.
 func (n *nextHopEntry) WithSubinterfaceRef(name string, subinterface uint64) *nextHopEntry {
-	if n.pb.NextHop == nil {
-		n.pb.NextHop = &aftpb.Afts_NextHop{}
-	}
 	n.pb.NextHop.InterfaceRef = &aftpb.Afts_NextHop_InterfaceRef{
 		Interface:    &wpb.StringValue{Value: name},
 		Subinterface: &wpb.UintValue{Value: subinterface},
@@ -850,9 +842,6 @@ func (n *nextHopEntry) WithSubinterfaceRef(name string, subinterface uint64) *ne
 
 // WithMacAddress specifies a MAC address to be used for the next-hop.
 func (n *nextHopEntry) WithMacAddress(mac string) *nextHopEntry {
-	if n.pb.NextHop == nil {
-		n.pb.NextHop = &aftpb.Afts_NextHop{}
-	}
 	n.pb.NextHop.MacAddress = &wpb.StringValue{Value: mac}
 	return n
 }
@@ -861,9 +850,6 @@ func (n *nextHopEntry) WithMacAddress(mac string) *nextHopEntry {
 // the next-hop, and the source and destination IP addresses for the
 // packet.
 func (n *nextHopEntry) WithIPinIP(srcIP, dstIP string) *nextHopEntry {
-	if n.pb.NextHop == nil {
-		n.pb.NextHop = &aftpb.Afts_NextHop{}
-	}
 	n.pb.NextHop.IpInIp = &aftpb.Afts_NextHop_IpInIp{
 		SrcIp: &wpb.StringValue{Value: srcIP},
 		DstIp: &wpb.StringValue{Value: dstIP},
@@ -877,9 +863,6 @@ func (n *nextHopEntry) WithIPinIP(srcIP, dstIP string) *nextHopEntry {
 // lookup uses the input packet within the specified network instance to determine the
 // next-hop.
 func (n *nextHopEntry) WithNextHopNetworkInstance(ni string) *nextHopEntry {
-	if n.pb.NextHop == nil {
-		n.pb.NextHop = &aftpb.Afts_NextHop{}
-	}
 	n.pb.NextHop.NetworkInstance = &wpb.StringValue{Value: ni}
 	return n
 }
@@ -888,9 +871,6 @@ func (n *nextHopEntry) WithNextHopNetworkInstance(ni string) *nextHopEntry {
 // packet. In this case, the exact value of the label to be popped need not be
 // specified.
 func (n *nextHopEntry) WithPopTopLabel() *nextHopEntry {
-	if n.pb.NextHop == nil {
-		n.pb.NextHop = &aftpb.Afts_NextHop{}
-	}
 	n.pb.NextHop.PopTopLabel = &wpb.BoolValue{Value: true}
 	return n
 }
@@ -900,9 +880,6 @@ func (n *nextHopEntry) WithPopTopLabel() *nextHopEntry {
 // in the inner-most to the outer-most such that the first label is the closest to the
 // bottom of the stack.
 func (n *nextHopEntry) WithPushedLabelStack(labels ...uint32) *nextHopEntry {
-	if n.pb.NextHop == nil {
-		n.pb.NextHop = &aftpb.Afts_NextHop{}
-	}
 	n.pb.NextHop.PushedMplsLabelStack = []*aftpb.Afts_NextHop_PushedMplsLabelStackUnion{}
 	for _, v := range labels {
 		lbl := &aftpb.Afts_NextHop_PushedMplsLabelStackUnion{
@@ -936,9 +913,6 @@ var (
 // WithDecapsulateHeader specifies that the next-hop should apply an action to decapsulate
 // the packet from the specified header, h.
 func (n *nextHopEntry) WithDecapsulateHeader(h Header) *nextHopEntry {
-	if n.pb.NextHop == nil {
-		n.pb.NextHop = &aftpb.Afts_NextHop{}
-	}
 	n.pb.NextHop.DecapsulateHeader = encapMap[h]
 	return n
 }
@@ -946,9 +920,6 @@ func (n *nextHopEntry) WithDecapsulateHeader(h Header) *nextHopEntry {
 // WithEncapsulateHeader specifies that the next-hop should apply an action to encapsulate
 // the packet with the specified header, h.
 func (n *nextHopEntry) WithEncapsulateHeader(h Header) *nextHopEntry {
-	if n.pb.NextHop == nil {
-		n.pb.NextHop = &aftpb.Afts_NextHop{}
-	}
 	n.pb.NextHop.EncapsulateHeader = encapMap[h]
 	return n
 }

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -572,24 +572,6 @@ func TestEntriesToModifyRequest(t *testing.T) {
 				},
 			}},
 		},
-	}, {
-		desc: "one NH entry delete with only index",
-		inOp: spb.AFTOperation_DELETE,
-		inEntries: []GRIBIEntry{
-			NextHopEntry().WithNetworkInstance("DEFAULT").WithIndex(1),
-		},
-		wantModifyRequest: &spb.ModifyRequest{
-			Operation: []*spb.AFTOperation{{
-				Id:              1,
-				NetworkInstance: "DEFAULT",
-				Op:              spb.AFTOperation_DELETE,
-				Entry: &spb.AFTOperation_NextHop{
-					NextHop: &aftpb.Afts_NextHopKey{
-						Index: 1,
-					},
-				},
-			}},
-		},
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Reverts openconfig/gribigo#240

Breaks tests.